### PR TITLE
make it safe to extend and use context type in middleware

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -12,7 +12,7 @@ import { Router, RouterOptions } from "./router.ts";
  * constructing an instance of `Application`.
  */
 export class Application<S extends object = { [key: string]: any }> {
-  private _middleware: Middleware<any, Context<any>>[] = [];
+  private _middleware: Middleware[] = [];
   private _serve: typeof serve;
 
   /** Generic state of the application, which can be specified by passing the
@@ -42,8 +42,10 @@ export class Application<S extends object = { [key: string]: any }> {
   }
 
   /** Register middleware to be used with the application. */
-  use<NS extends {} = S>(middleware: Middleware<NS, Context<NS>>) {
+  use<NS extends {} = S>(
+    middleware: Middleware<NS, Context<NS>>
+  ): Application<NS extends S ? NS : (S & NS)> {
     this._middleware.push(middleware);
-    return (this as unknown) as Application<NS extends S ? NS : (S & NS)>;
+    return this as any;
   }
 }

--- a/application.ts
+++ b/application.ts
@@ -2,7 +2,8 @@
 
 import { Context } from "./context.ts";
 import { compose, Middleware } from "./middleware.ts";
-import { serve, Server } from "./deps.ts";
+import { serve } from "./deps.ts";
+import { Router, RouterOptions } from "./router.ts";
 
 /** A class which registers middleware (via `.use()`) and then processes
  * inbound requests against that middleware (via `.listen()`).
@@ -11,7 +12,7 @@ import { serve, Server } from "./deps.ts";
  * constructing an instance of `Application`.
  */
 export class Application<S extends object = { [key: string]: any }> {
-  private _middleware: Middleware<S, Context<S>>[] = [];
+  private _middleware: Middleware<any, Context<any>>[] = [];
   private _serve: typeof serve;
 
   /** Generic state of the application, which can be specified by passing the
@@ -24,7 +25,9 @@ export class Application<S extends object = { [key: string]: any }> {
   constructor(_serve = serve) {
     this._serve = _serve;
   }
-
+  createRouter(options: RouterOptions = {}): Router<S> {
+    return new Router<S>(options);
+  }
   /** Start listening for requests, processing registered middleware on each
    * request.
    */
@@ -39,8 +42,8 @@ export class Application<S extends object = { [key: string]: any }> {
   }
 
   /** Register middleware to be used with the application. */
-  use(...middleware: Middleware<S, Context<S>>[]): this {
-    this._middleware.push(...middleware);
-    return this;
+  use<NS extends {} = S>(middleware: Middleware<NS, Context<NS>>) {
+    this._middleware.push(middleware);
+    return (this as unknown) as Application<NS extends S ? NS : (S & NS)>;
   }
 }

--- a/router.ts
+++ b/router.ts
@@ -107,7 +107,7 @@ class Layer {
   constructor(
     public path: string,
     public methods: HTTPMethods[],
-    middleware: RouterMiddleware<any, any> | RouterMiddleware[],
+    middleware: RouterMiddleware | RouterMiddleware[],
     public options: LayerOptions = {}
   ) {
     this.name = options.name || null;


### PR DESCRIPTION
According to #21. 

By this patch, middleware got ability to extend context type, for example from `Context<{}>` to `Context<{user: {id: string}}>`, which can be safely used in followed-up middleware or router handler.

```ts
const app = new Application()
  .use((ctx: Context<{ user: { id: string } }>, next) => {
    ctx.state.user.id = ctx.request.headers.get("uid");
  })
  .use((ctx: Context<{ user: { name: string } }>, next) => {
    // safe to access ctx.state.user.id now
    ctx.state.user.name = Users.get(ctx.state.user.id);
    return next();
  });
const router = app.createRouter();
router.get("/logout", context => {
  // ctx's type generated from all previous application middlewares
  ctx.response.body = `user ${ctx.state.user.name}(${ctx.state.user.id}) logged out`;
});
```

_**Breaking change**_ need to be aware of:
`app.use` takes only one middleware parameter now.

P.S. 
I also think it would be better to have `router.use` API(middleware which only apply to router prefix paths). But might need some change on route matching process.
