### PR TITLE
Replace + with space in form-urlencoded bodies

### DIFF
--- a/request.ts
+++ b/request.ts
@@ -172,7 +172,7 @@ export class Request {
       } else if (isMediaType(contentType, formTypes)) {
         return (this._body = {
           type: BodyType.Form,
-          value: new URLSearchParams(str)
+          value: new URLSearchParams(str.replace(/\+/g, " "))
         });
       } else if (isMediaType(contentType, textTypes)) {
         return (this._body = { type: BodyType.Text, value: str });

--- a/request_test.ts
+++ b/request_test.ts
@@ -119,7 +119,7 @@ test(async function requestBodyJson() {
 
 test(async function requestBodyForm() {
   const request = new Request(
-    createMockServerRequest("/", `foo=bar&bar=1`, {
+    createMockServerRequest("/", `foo=bar&bar=1&baz=qux+%2B+quux`, {
       "Content-Type": "application/x-www-form-urlencoded"
     })
   );
@@ -128,7 +128,8 @@ test(async function requestBodyForm() {
   if (actual && actual.type === "form") {
     assertEquals(Array.from(actual.value.entries()), [
       ["foo", "bar"],
-      ["bar", "1"]
+      ["bar", "1"],
+      ["baz", "qux + quux"]
     ]);
   } else {
     throw Error("Unexpected response");


### PR DESCRIPTION
In [x-www-form-urlencoded][ref] request bodies, spaces are encoded as `+`. This replaces all `+` characters before instantiating `URLSearchParams`.

[ref]: https://en.wikipedia.org/wiki/Percent-encoding#The_application/x-www-form-urlencoded_type