### PR TITLE
searchMap property - search params as object

### DIFF
--- a/request.ts
+++ b/request.ts
@@ -7,6 +7,32 @@ import { isMediaType } from "./isMediaType.ts";
 import { preferredMediaTypes } from "./mediaType.ts";
 import { HTTPMethods } from "./types.ts";
 
+type SearchMap = {
+  [k: string]: string | string[];
+};
+
+class OakURLSearchParams extends URLSearchParams {
+  private _searchMap: SearchMap;
+
+  constructor(init?: string | string[][] | Record<string, string>) {
+    super(init);
+
+    this.initializeSearchMap();
+  }
+
+  private initializeSearchMap(): void {
+    const searchKeys = this.keys();
+
+    for (let searchKey of searchKeys) {
+      this._searchMap[searchKey] = this.getAll(searchKey);
+    }
+  }
+
+  get searchMap(): SearchMap {
+    return this._searchMap;
+  }
+}
+
 export enum BodyType {
   JSON = "json",
   Form = "form",
@@ -31,7 +57,7 @@ export class Request {
   private _path: string;
   private _rawBodyPromise?: Promise<Uint8Array>;
   private _search?: string;
-  private _searchParams: URLSearchParams;
+  private _searchParams: OakURLSearchParams;
   private _serverRequest: ServerRequest;
 
   /** Is `true` if the request has a body, otherwise `false`. */
@@ -62,8 +88,8 @@ export class Request {
     return this._search;
   }
 
-  /** The parsed `URLSearchParams` of the request. */
-  get searchParams(): URLSearchParams {
+  /** The parsed `OakURLSearchParams` of the request. */
+  get searchParams(): OakURLSearchParams {
     return this._searchParams;
   }
 
@@ -82,7 +108,7 @@ export class Request {
     const [path, search] = serverRequest.url.split("?");
     this._path = path;
     this._search = search ? `?${search}` : undefined;
-    this._searchParams = new URLSearchParams(search);
+    this._searchParams = new OakURLSearchParams(search);
   }
 
   /** Returns an array of media types, accepted by the requestor, in order of

--- a/request_test.ts
+++ b/request_test.ts
@@ -9,6 +9,7 @@ import {
 import { ServerRequest } from "./deps.ts";
 import httpErrors from "./httpError.ts";
 import { Request, BodyType } from "./request.ts";
+import { assert } from "C:/Users/HP/AppData/Local/deno/deps/https/deno.land/std@v0.32.0/testing/asserts";
 
 const encoder = new TextEncoder();
 
@@ -58,6 +59,10 @@ test(function requestSearch() {
     ["bar", "baz"],
     ["qat", "qux"]
   ]);
+  assertEquals(request.searchParams.searchMap, {
+    bar: "baz",
+    qat: "qux"
+  })
 });
 
 test(function serverRequestAvail() {


### PR DESCRIPTION
Hi,

I am trying to rewrite some node.js app with deno and I am using oak.

I have some routings that uses query params and sometimes there are a lot of query params that user can pass. As far as I can see, query/search params are handled with URLSearchParams and there is no option to get all query params as simple object and simply destructure it to get required values. Now I have to use URLSearchParams.get to get these params one by one.

So, current behavior: 
```
const A = ctx.request.searchParams.get("A");
const B = ctx.request.searchParams.get("B");
const C = ctx.request.searchParams.get("C");
const D = ctx.request.searchParams.get("D");
const E = ctx.request.searchParams.get("E");
```

expected behavior:

`const { A, B, C, D, E } = ctx.request.searchParams.paramsMap();`

Maybe this could be achieved by simply extend URLSearchParams