### PR TITLE
FIX breaking change from deno 0.37: update FileInfo.len to FileInfo.size

### DIFF
--- a/send.ts
+++ b/send.ts
@@ -151,7 +151,7 @@ export async function send(
     throw createHttpError(500, err.message);
   }
 
-  response.headers.set("Content-Length", String(stats.len));
+  response.headers.set("Content-Length", String(stats.size));
   if (!response.headers.has("Last-Modified") && stats.modified) {
     response.headers.set("Last-Modified", toUTCString(stats.modified));
   }


### PR DESCRIPTION
deno made a breaking change to FileInfo -- .len is now .size in the 0.37.0 release of deno yesterday.
The change is outlined here: https://github.com/denoland/deno/pull/4338

Issue in oak was open here: https://github.com/oakserver/oak/issues/48

tested locally pointing at my changes, and oak now compiles (doesn't get caught on a type error) and all is good in the world.

Without this fix, the error message was:
```
error TS2339: Property 'len' does not exist on type 'FileInfo'.

► https://deno.land/x/oak/send.ts:154:55

154   response.headers.set("Content-Length", String(stats.len));
```