### PR TITLE
Fix Calls to `Deno.stat` in `send` Function.

### DIFF
--- a/send.ts
+++ b/send.ts
@@ -59,7 +59,7 @@ function isHidden(root: string, path: string) {
 
 async function exists(path: string): Promise<boolean> {
   try {
-    return (await Deno.stat(path)).isFile();
+    return (await Deno.stat(path)).isFile;
   } catch {
     return false;
   }
@@ -136,7 +136,7 @@ export async function send(
   try {
     stats = await Deno.stat(path);
 
-    if (stats.isDirectory()) {
+    if (stats.isDirectory) {
       if (format && index) {
         path += `/${index}`;
         stats = await Deno.stat(path);


### PR DESCRIPTION
Calling `isFile` and `isDirectory` as functions caused an error when
running tests and loading Oak on Deno v0.41.