### PR TITLE
Fix contentTypes spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ And several methods:
   ```ts
   app.use((ctx) => {
     const result = await ctx.request.body({
-      contextTypes: {
+      contentTypes: {
         text: ["application/javascript"],
       },
     });


### PR DESCRIPTION
Change contextTypes to contentTypes on line 260 in README.md