### PR TITLE
Use deps consistently

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -4,13 +4,13 @@ import { Context } from "./context.ts";
 import {
   serve as defaultServe,
   serveTLS as defaultServeTls,
+  Server,
   ServerRequest,
   Status,
   STATUS_TEXT,
 } from "./deps.ts";
 import { Key, KeyStack } from "./keyStack.ts";
 import { compose, Middleware } from "./middleware.ts";
-import { Server } from "https://deno.land/std@0.51.0/http/server.ts";
 export interface ListenOptionsBase {
   hostname?: string;
   port: number;

--- a/application_test.ts
+++ b/application_test.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
-import { test, assert, assertEquals, assertStrictEq } from "./test_deps.ts";
+import {
+  test,
+  assert,
+  assertEquals,
+  assertStrictEq,
+  assertThrowsAsync,
+} from "./test_deps.ts";
 import { Application, ListenOptions, ListenOptionsTls } from "./application.ts";
 import { Context } from "./context.ts";
 import {
@@ -11,7 +17,6 @@ import {
 } from "./deps.ts";
 import { Data, KeyStack } from "./keyStack.ts";
 import { httpErrors } from "./httpError.ts";
-import { assertThrowsAsync } from "https://deno.land/std@0.51.0/testing/asserts.ts";
 let serverRequestStack: ServerRequest[] = [];
 let requestResponseStack: ServerResponse[] = [];
 let addrStack: Array<string | ListenOptions> = [];

--- a/keyStack_test.ts
+++ b/keyStack_test.ts
@@ -1,8 +1,7 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
 import { KeyStack } from "./keyStack.ts";
-import { assertEquals } from "./test_deps.ts";
-import { assert } from "https://deno.land/std@0.51.0/testing/asserts.ts";
+import { assert, assertEquals } from "./test_deps.ts";
 const { test } = Deno;
 
 test({

--- a/middleware_test.ts
+++ b/middleware_test.ts
@@ -1,13 +1,12 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
-import { test, assertEquals, assertStrictEq } from "./test_deps.ts";
+import { test, assert, assertEquals, assertStrictEq } from "./test_deps.ts";
 import { State } from "./application.ts";
 import { Context } from "./context.ts";
 import { Status } from "./deps.ts";
 import { createHttpError, httpErrors } from "./httpError.ts";
 import { ErrorStatus } from "./types.d.ts";
 import { compose, Middleware } from "./middleware.ts";
-import { assert } from "https://deno.land/std@0.51.0/testing/asserts.ts";
 function createMockContext<S extends State = Record<string, any>>() {
   return ({
     request: {

--- a/request_test.ts
+++ b/request_test.ts
@@ -2,13 +2,13 @@
 
 import {
   test,
+  assert,
   assertEquals,
   assertStrictEq,
+  decoder,
 } from "./test_deps.ts";
 import { ServerRequest } from "./deps.ts";
 import { Request } from "./request.ts";
-import { assert } from "https://deno.land/std@0.51.0/testing/asserts.ts";
-import { decoder } from "https://deno.land/std@0.51.0/encoding/utf8.ts";
 const encoder = new TextEncoder();
 
 function createMockBodyReader(body: string): Deno.Reader {

--- a/response_test.ts
+++ b/response_test.ts
@@ -1,10 +1,9 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
 import { Status } from "./deps.ts";
-import { test, assertEquals } from "./test_deps.ts";
+import { test, assert, assertEquals } from "./test_deps.ts";
 import { Request } from "./request.ts";
 import { Response, REDIRECT_BACK } from "./response.ts";
-import { assert } from "https://deno.land/std@0.51.0/testing/asserts.ts";
 const decoder = new TextDecoder();
 
 function decodeBody(body: Uint8Array | Deno.Reader | undefined): string {

--- a/router_test.ts
+++ b/router_test.ts
@@ -1,14 +1,15 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
-import { assertEquals, assertStrictEq, test } from "./test_deps.ts";
+import {
+  assertEquals,
+  assertStrictEq,
+  assertThrowsAsync,
+  test,
+} from "./test_deps.ts";
 import { Application } from "./application.ts";
 import { Context } from "./context.ts";
 import { Status } from "./deps.ts";
 import { Router } from "./router.ts";
-import {
-  assertThrows,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.51.0/testing/asserts.ts";
 function createMockApp<
   S extends Record<string | number | symbol, any> = Record<string, any>,
 >(

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -9,3 +9,5 @@ export {
   assertThrows,
   assertThrowsAsync,
 } from "https://deno.land/std@0.51.0/testing/asserts.ts";
+
+export { decoder } from "https://deno.land/std@0.51.0/encoding/utf8.ts";


### PR DESCRIPTION
Use deps.ts consistently for dependencies.

After this change the only absolute URLs are found in deps.ts (of course) and in test code. Currently deps.ts seems to capture "production" dependencies pretty well, so I would propose adding a dev_deps.ts to capture the asserts from the test code. That change can be made separately but I'd love to hear your thoughts!

Edit: I just noticed test_deps.ts so I've updated the imports in the test code too. Seems like there's a split on which name to use! :)