### PR TITLE
Un-Strict Prefix routing fix

### DIFF
--- a/examples/routePrefix.ts
+++ b/examples/routePrefix.ts
@@ -1,0 +1,39 @@
+import {
+  Application,
+  Router,
+} from "../mod.ts";
+const router = new Router({
+  prefix: "/prefix",
+  // strict: true,
+});
+
+const port = 4000;
+
+const server = new Application();
+
+server.use(
+  router.routes(),
+  router.allowedMethods(),
+);
+
+router
+  .get("/", ({ response }: { response: any }) => {
+    response.status = 200;
+    response.body = { msg: "Prefix works" };
+  })
+  .get(
+    "/:id",
+    ({ params, response }: { params: { id: string }; response: any }) => {
+      response.body = `prefix w/ id: ${params.id}`;
+    },
+  )
+  .get(
+    "/test",
+    ({ params, response }: { params: { id: string }; response: any }) => {
+      response.body = `test`;
+    },
+  );
+
+console.log("server running");
+
+await server.listen({ port });

--- a/router.ts
+++ b/router.ts
@@ -95,9 +95,6 @@ export interface RouterOptions {
    * optional.  Defaults to `false`.
    */
   strict?: boolean;
-
-  /**end */
-  end?: boolean;
 }
 
 interface LayerOptions {
@@ -105,7 +102,6 @@ interface LayerOptions {
   name?: string;
   sensitive?: boolean;
   strict?: boolean;
-  end?: boolean;
 }
 
 class Layer {

--- a/router.ts
+++ b/router.ts
@@ -121,13 +121,10 @@ class Layer {
     if (this.methods.includes("GET")) {
       this.methods.unshift("HEAD");
     }
-    console.log("path", path, "params", this.paramNames, "options", options);
     this.regexp = pathToRegexp(path, this.paramNames, options);
   }
 
   matches(path: string): boolean {
-    console.log("matches path", path);
-    console.log("regex test for path:", this.regexp.test(path));
     return this.regexp.test(path);
   }
 
@@ -149,45 +146,25 @@ class Layer {
       return [];
     }
     const [, ...captures] = path.match(this.regexp)!;
-    console.log("captures", captures);
     return captures;
   }
 
   setPrefix(prefix: string): this {
     if (this.path) {
-      //fix
-      console.log("before path:", this.path);
       if (this.path === "/" && !this.options.strict) {
-        // check if path is set to "base" and the strict option
+        // check if path is set to "base" and the strict option is set to false
         this.path = `${prefix}`;
       } else {
         this.path = `${prefix}${this.path}`;
       }
-
-      console.log(" after path:", this.path);
       this.paramNames = [];
-      console.log("reg options: ", this.options);
-      console.log("setPrefix before regexp :", this.regexp);
-      console.log(
-        "SETPREFIX:  ",
-        "path",
-        this.path,
-        "params",
-        this.paramNames,
-        "options",
-        this.options,
-      );
-      const regexFix = pathToRegexp("/prefix", this.paramNames, this.options);
-      console.log("regexFix: ", regexFix);
       this.regexp = pathToRegexp(this.path, this.paramNames, this.options);
-      console.log("setPrefix after regexp :", this.regexp);
     }
     return this;
   }
 }
 
 function inspectLayer(layer: Layer): Route {
-  console.log("inpspectLayer", layer);
   const { path, methods, stack, options, regexp } = layer;
   return {
     path,
@@ -208,7 +185,6 @@ export class Router {
   #prefix = "";
   #stack: Layer[] = [];
   #strict = false;
-  #end = false;
 
   #addRoute = (
     path: string | string[],
@@ -262,11 +238,9 @@ export class Router {
     ];
     if (prefix) {
       this.#prefix = prefix;
-      console.log("router option prefix", prefix);
     }
     if (strict) {
       this.#strict = strict;
-      console.log("router option strict::", strict);
     }
   }
 


### PR DESCRIPTION
### Un-Strict Prefix routing fix

as @aldinp16 mention **`setPrefix()`** is where it seems to go wrong and its correct  😬.
oak uses [path-to-regexp](https://github.com/pillarjs/path-to-regexp) to return the regex that creates matches for the routes. One of the arguments it needs it's the path, when we set an endpoint with the base path **`'/'`** the **`setPrefix()`** function is putting the  prefix and the path together
```ts
this.path = `${prefix}${this.path}`
```

which when we send to **`pathToRegexp()`** even with the strict flag as false we are still passing the path with the **strict** trailing **/** because those 2 are put together so it returns a regex that needs to verify that last **/** as part of the path hence it is on a permanent strict mode.

### FIX

debugging was the hard part but the fix is relatively easy. We just have to check if we have a "base" path **/** and if the strict option is false. if those things are both true we just set the path to its prefix **`this.path = `${prefix}`;`** else continue as usual with this.path = `${prefix}${this.path}`;

```ts
 if (this.path === "/" && !this.options.strict) {
        // check if path is set to "base" and the strict option
        this.path = `${prefix}`;
      } else {
        this.path = `${prefix}${this.path}`;
      }
```

Fixes #91