### PR TITLE
Fix encode uri on redirect

### DIFF
--- a/response.ts
+++ b/response.ts
@@ -2,7 +2,7 @@
 
 import { contentType, Status } from "./deps.ts";
 import { Request } from "./request.ts";
-import { isHtml, isRedirectStatus } from "./util.ts";
+import { isHtml, isRedirectStatus, encodeUrl } from "./util.ts";
 
 interface ServerResponse {
   status?: number;
@@ -20,18 +20,6 @@ const encoder = new TextEncoder();
 function isReader(value: any): value is Deno.Reader {
   return typeof value === "object" && "read" in value &&
     typeof value.read === "function";
-}
-
-const ENCODE_CHARS_REGEXP = /(?:[^\x21\x25\x26-\x3B\x3D\x3F-\x5B\x5D\x5F\x61-\x7A\x7E]|%(?:[^0-9A-Fa-f]|[0-9A-Fa-f][^0-9A-Fa-f]|$))+/g
-
-const UNMATCHED_SURROGATE_PAIR_REGEXP = /(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF]([^\uDC00-\uDFFF]|$)/g;
-
-const UNMATCHED_SURROGATE_PAIR_REPLACE = '$1\uFFFD$2';
-
-function encodeUrl (url: string) {
-  return String(url)
-    .replace(UNMATCHED_SURROGATE_PAIR_REGEXP, UNMATCHED_SURROGATE_PAIR_REPLACE)
-    .replace(ENCODE_CHARS_REGEXP, encodeURI)
 }
 
 export class Response {

--- a/response_test.ts
+++ b/response_test.ts
@@ -291,6 +291,20 @@ test({
 });
 
 test({
+  name: "response.redirect() with url on query string",
+  fn() {
+    const response = new Response(createMockRequest());
+    response.redirect("https://example.com/foo?redirect=https%3A%2F%2Fdeno.land");
+    const serverResponse = response.toServerResponse();
+    assertEquals(serverResponse.status, Status.Found);
+    assertEquals(
+      serverResponse.headers?.get("Location"),
+      "https://example.com/foo?redirect=https%3A%2F%2Fdeno.land",
+    );
+  },
+});
+
+test({
   name: "response.body() passes Deno.Reader",
   fn() {
     const response = new Response(createMockRequest());


### PR DESCRIPTION
Fixes #119  

The koa framework uses this function to encode URI.
https://github.com/koajs/koa/blob/master/lib/response.js#L20
https://github.com/pillarjs/encodeurl/blob/master/index.js