### PR TITLE
Fix Author name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ const books = new Map<string, any>();
 books.set("1", {
   id: "1",
   title: "The Hound of the Baskervilles",
-  author: "Conan Doyle, Author",
+  author: "Conan Doyle, Arthur",
 });
 
 const router = new Router();


### PR DESCRIPTION
I know this fix is extremely important, but nonetheless: one of the README examples uses "Conan Doyle, Author" instead of ".. Arthur".

That's all, thanks