### PR TITLE
Update send.ts

### DIFF
--- a/context_test.ts
+++ b/context_test.ts
@@ -90,7 +90,13 @@ test({
     );
     const fixture = await Deno.readFile("./fixtures/test.html");
     await context.send({ root: "./fixtures" });
-    assertEquals(context.response.body, fixture);
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".html");
     assertEquals(
       context.response.headers.get("content-length"),
@@ -110,7 +116,13 @@ test({
     );
     const fixture = await Deno.readFile("./fixtures/test.html");
     await context.send({ path: "/test.html", root: "./fixtures" });
-    assertEquals(context.response.body, fixture);
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".html");
     assertEquals(
       context.response.headers.get("content-length"),

--- a/deps.ts
+++ b/deps.ts
@@ -33,6 +33,7 @@ export {
   resolve,
   sep,
 } from "https://deno.land/std@0.53.0/path/mod.ts";
+export { BufReader } from "https://deno.land/std@0.53.0/io/bufio.ts";
 export { assert } from "https://deno.land/std@0.53.0/testing/asserts.ts";
 
 // 3rd party dependencies

--- a/send.ts
+++ b/send.ts
@@ -48,7 +48,7 @@ export interface SendOptions {
   extensions?: string[];
     /** Buffer size for sending files. There must be a good relationship between
      * memory consumption and overhead. I recommend 32k. */
-  buffSize: number;
+  buffSize?: number;
 }
 
 function isHidden(root: string, path: string) {
@@ -76,7 +76,7 @@ async function exists(path: string): Promise<boolean> {
 export async function send(
   { request, response }: Context,
   path: string,
-  options: SendOptions = { root: "", buffSize: 32000 },
+  options: SendOptions = { root: "" },
 ): Promise<string | undefined> {
   const {
     brotli = true,
@@ -88,7 +88,7 @@ export async function send(
     immutable = false,
     maxage = 0,
     root,
-    buffSize
+    buffSize = 32000
   } = options;
   const trailingSlash = path[path.length - 1] === "/";
   path = decodeComponent(path.substr(parse(path).root.length));
@@ -171,7 +171,7 @@ export async function send(
       : extname(path);
   }
   const file = await Deno.open(path);
-  const bufReader = new BufReader(file,options.buffSize);
+  const bufReader = new BufReader(file,buffSize);
   response.body = bufReader;
 
   return path;

--- a/send.ts
+++ b/send.ts
@@ -46,8 +46,9 @@ export interface SendOptions {
    * `undefined`) */
 
   extensions?: string[];
-    /** Buffer size for sending files. There must be a good relationship between
-     * memory consumption and overhead. I recommend 32k. */
+  
+  /** Buffer size for sending files. There must be a good relationship between
+   * memory consumption and overhead. I recommend 32k. */
   buffSize?: number;
 }
 

--- a/send.ts
+++ b/send.ts
@@ -44,12 +44,11 @@ export interface SendOptions {
   /** Try to match extensions from passed array to search for file when no
    * extension is sufficed in URL. First found is served. (defaults to
    * `undefined`) */
-
   extensions?: string[];
-  
-  /** Buffer size for sending files. There must be a good relationship between
-   * memory consumption and overhead. I recommend 32k. */
-  buffSize?: number;
+
+  /** The number of bytes per segment to read the file from
+   * the file system.  Defaults to 32k. */
+  segmentSize?: number;
 }
 
 function isHidden(root: string, path: string) {
@@ -89,7 +88,7 @@ export async function send(
     immutable = false,
     maxage = 0,
     root,
-    buffSize = 32000
+    segmentSize = 32000
   } = options;
   const trailingSlash = path[path.length - 1] === "/";
   path = decodeComponent(path.substr(parse(path).root.length));
@@ -172,7 +171,7 @@ export async function send(
       : extname(path);
   }
   const file = await Deno.open(path);
-  const bufReader = new BufReader(file,buffSize);
+  const bufReader = new BufReader(file, segmentSize);
   response.body = bufReader;
 
   return path;

--- a/send.ts
+++ b/send.ts
@@ -48,7 +48,7 @@ export interface SendOptions {
   extensions?: string[];
     /** Buffer size for sending files. There must be a good relationship between
      * memory consumption and overhead. I recommend 32k. */
-  buffSize?: number;
+  buffSize: number;
 }
 
 function isHidden(root: string, path: string) {

--- a/send.ts
+++ b/send.ts
@@ -88,6 +88,7 @@ export async function send(
     immutable = false,
     maxage = 0,
     root,
+    buffSize
   } = options;
   const trailingSlash = path[path.length - 1] === "/";
   path = decodeComponent(path.substr(parse(path).root.length));

--- a/send.ts
+++ b/send.ts
@@ -1,178 +1,182 @@
-/*!
- * Adapted from koa-send at https://github.com/koajs/send and which is licensed
- * with the MIT license.
- */
+// Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
+import { assert, assertEquals, assertStrictEq, test } from "./test_deps.ts";
+
+import { Application } from "./application.ts";
 import { Context } from "./context.ts";
-import { createHttpError } from "./httpError.ts";
-import { basename, extname, parse, sep, BufReader } from "./deps.ts";
-import { decodeComponent, resolvePath } from "./util.ts";
+import { Status } from "./deps.ts";
+import { httpErrors } from "./httpError.ts";
+import { send } from "./send.ts";
 
-export interface SendOptions {
-  /** Browser cache max-age in milliseconds. (defaults to `0`) */
-  maxage?: number;
+let encodingsAccepted = "identity";
 
-  /** Tell the browser the resource is immutable and can be cached
-   * indefinitely. (defaults to `false`) */
-  immutable?: boolean;
-
-  /** Allow transfer of hidden files. (defaults to `false`) */
-  hidden?: boolean;
-
-  /** Root directory to restrict file access. */
-  root: string;
-
-  /** Name of the index file to serve automatically when visiting the root
-   * location. (defaults to none) */
-  index?: string;
-
-  /** Try to serve the gzipped version of a file automatically when gzip is
-   * supported by a client and if the requested file with `.gz` extension
-   * exists. (defaults to `true`). */
-  gzip?: boolean;
-
-  /** Try to serve the brotli version of a file automatically when brotli is
-   * supported by a client and if the requested file with `.br` extension
-   * exists. (defaults to `true`) */
-  brotli?: boolean;
-
-  /** If `true`, format the path to serve static file servers and not require a
-   * trailing slash for directories, so that you can do both `/directory` and
-   * `/directory/`. (defaults to `true`) */
-  format?: boolean;
-
-  /** Try to match extensions from passed array to search for file when no
-   * extension is sufficed in URL. First found is served. (defaults to
-   * `undefined`) */
-  extensions?: string[];
-
-  /** The number of bytes per segment to read the file from
-   * the file system.  Defaults to 32k. */
-  segmentSize?: number;
+function createMockApp<
+  S extends Record<string | number | symbol, any> = Record<string, any>,
+>(
+  state = {} as S,
+): Application<S> {
+  return {
+    state,
+  } as any;
 }
 
-function isHidden(root: string, path: string) {
-  const pathArr = path.substr(root.length).split(sep);
-  for (const segment of pathArr) {
-    if (segment[0] === ".") {
-      return true;
-    }
-    return false;
-  }
+function createMockContext<
+  S extends Record<string | number | symbol, any> = Record<string, any>,
+>(
+  app: Application<S>,
+  path = "/",
+  method = "GET",
+) {
+  return ({
+    app,
+    request: {
+      acceptsEncodings() {
+        return encodingsAccepted;
+      },
+      headers: new Headers(),
+      method,
+      path,
+      search: undefined,
+      searchParams: new URLSearchParams(),
+      url: new URL(`http://localhost${path}`),
+    },
+    response: {
+      status: Status.OK,
+      body: undefined,
+      headers: new Headers(),
+    },
+    state: app.state,
+  } as unknown) as Context<S>;
 }
 
-async function exists(path: string): Promise<boolean> {
-  try {
-    return (await Deno.stat(path)).isFile;
-  } catch {
-    return false;
-  }
+function setup<
+  S extends Record<string | number | symbol, any> = Record<string, any>,
+>(
+  path = "/",
+  method = "GET",
+): {
+  app: Application<S>;
+  context: Context<S>;
+} {
+  encodingsAccepted = "identity";
+  const app = createMockApp<S>();
+  const context = createMockContext<S>(app, path, method);
+  return { app, context };
 }
 
-/** Asynchronously fulfill a response with a file from the local file
- * system.
- * 
- * Requires Deno read permission. */
-export async function send(
-  { request, response }: Context,
-  path: string,
-  options: SendOptions = { root: "" },
-): Promise<string | undefined> {
-  const {
-    brotli = true,
-    extensions,
-    format = true,
-    gzip = true,
-    index,
-    hidden = false,
-    immutable = false,
-    maxage = 0,
-    root,
-    segmentSize = 32000
-  } = options;
-  const trailingSlash = path[path.length - 1] === "/";
-  path = decodeComponent(path.substr(parse(path).root.length));
-  if (index && trailingSlash) {
-    path += index;
-  }
-
-  path = resolvePath(root, path);
-
-  if (!hidden && isHidden(root, path)) {
-    return;
-  }
-
-  let encodingExt = "";
-  if (
-    brotli &&
-    request.acceptsEncodings("br", "identity") === "br" &&
-    (await exists(`${path}.br`))
-  ) {
-    path = `${path}.br`;
-    response.headers.set("Content-Encoding", "br");
-    response.headers.delete("Content-Length");
-    encodingExt = ".br";
-  } else if (
-    gzip &&
-    request.acceptsEncodings("gzip", "identity") === "gzip" &&
-    (await exists(`${path}.gz`))
-  ) {
-    path = `${path}.gz`;
-    response.headers.set("Content-Encoding", "gzip");
-    response.headers.delete("Content-Length");
-    encodingExt = ".gz";
-  }
-
-  if (extensions && !/\.[^/]*$/.exec(path)) {
-    for (let ext of extensions) {
-      if (!/^\./.exec(ext)) {
-        ext = `.${ext}`;
-      }
-      if (await exists(`${path}${ext}`)) {
-        path += ext;
-        break;
-      }
+test({
+  name: "send HTML",
+  async fn() {
+    const { context } = setup("/test.html");
+    const fixture = await Deno.readFile("./fixtures/test.html");
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
     }
-  }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
+    assertEquals(context.response.type, ".html");
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+    assert(context.response.headers.get("last-modified") != null);
+    assertEquals(context.response.headers.get("cache-control"), "max-age=0");
+  },
+});
 
-  let stats: Deno.FileInfo;
-  try {
-    stats = await Deno.stat(path);
-
-    if (stats.isDirectory) {
-      if (format && index) {
-        path += `/${index}`;
-        stats = await Deno.stat(path);
-      } else {
-        return;
-      }
+test({
+  name: "send gzip",
+  async fn() {
+    const { context } = setup("/test.json");
+    const fixture = await Deno.readFile("./fixtures/test.json.gz");
+    encodingsAccepted = "gzip";
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
     }
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      throw createHttpError(404, err.message);
-    }
-    throw createHttpError(500, err.message);
-  }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
+    assertEquals(context.response.type, ".json");
+    assertEquals(context.response.headers.get("content-encoding"), "gzip");
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+  },
+});
 
-  response.headers.set("Content-Length", String(stats.size));
-  if (!response.headers.has("Last-Modified") && stats.mtime) {
-    response.headers.set("Last-Modified", stats.mtime.toUTCString());
-  }
-  if (!response.headers.has("Cache-Control")) {
-    const directives = [`max-age=${(maxage / 1000) | 0}`];
-    if (immutable) {
-      directives.push("immutable");
+test({
+  name: "send brotli",
+  async fn() {
+    const { context } = setup("/test.json");
+    const fixture = await Deno.readFile("./fixtures/test.json.br");
+    encodingsAccepted = "br";
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
     }
-    response.headers.set("Cache-Control", directives.join(","));
-  }
-  if (!response.type) {
-    response.type = encodingExt !== ""
-      ? extname(basename(path, encodingExt))
-      : extname(path);
-  }
-  const file = await Deno.open(path);
-  const bufReader = new BufReader(file, segmentSize);
-  response.body = bufReader;
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(context.response.body, fixture);
+    assertEquals(context.response.type, ".json");
+    assertEquals(context.response.headers.get("content-encoding"), "br");
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+  },
+});
 
-  return path;
-}
+test({
+  name: "send identity",
+  async fn() {
+    const { context } = setup("/test.json");
+    const fixture = await Deno.readFile("./fixtures/test.json");
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
+    assertEquals(context.response.type, ".json");
+    assertStrictEq(context.response.headers.get("content-encoding"), null);
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+  },
+});
+
+test({
+  name: "send 404",
+  async fn() {
+    const { context } = setup("/foo.txt");
+    encodingsAccepted = "identity";
+    let didThrow = false;
+    try {
+      await send(context, context.request.url.pathname, {
+        root: "./fixtures",
+      });
+    } catch (e) {
+      assert(e instanceof httpErrors.NotFound);
+      didThrow = true;
+    }
+    assert(didThrow);
+  },
+});

--- a/send_test.ts
+++ b/send_test.ts
@@ -129,7 +129,7 @@ test({
       tempArray.push(byte);
     }
     let bytes = Uint8Array.from(tempArray);
-    assertEquals(context.response.body, fixture);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".json");
     assertEquals(context.response.headers.get("content-encoding"), "br");
     assertEquals(

--- a/send_test.ts
+++ b/send_test.ts
@@ -72,7 +72,13 @@ test({
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
     });
-    assertEquals(context.response.body, fixture);
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".html");
     assertEquals(
       context.response.headers.get("content-length"),
@@ -92,7 +98,13 @@ test({
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
     });
-    assertEquals(context.response.body, fixture);
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".json");
     assertEquals(context.response.headers.get("content-encoding"), "gzip");
     assertEquals(
@@ -111,6 +123,12 @@ test({
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
     });
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
     assertEquals(context.response.body, fixture);
     assertEquals(context.response.type, ".json");
     assertEquals(context.response.headers.get("content-encoding"), "br");
@@ -129,7 +147,13 @@ test({
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
     });
-    assertEquals(context.response.body, fixture);
+    let tempArray = new Array();
+    let byte;
+    while ((byte = await context.response.body.readByte()) !== null) {
+      tempArray.push(byte);
+    }
+    let bytes = Uint8Array.from(tempArray);
+    assertEquals(bytes, fixture);
     assertEquals(context.response.type, ".json");
     assertStrictEq(context.response.headers.get("content-encoding"), null);
     assertEquals(


### PR DESCRIPTION
The function created to send static files (oak / send.ts) is cool, but it has a big problem: to send a file, the file is loaded completely into memory. This is a problem because, for example, if there are thousands of simultaneous requests, and there is a 1MB static file, the server will have GB's of memory occupied and will probably die. This is also a problem if there is a large file to send, even with few requests. The modifications I made send the files via Buffer, which solves the problem and makes the function scalable.