### PR TITLE
Update deps.ts for changes in send.ts

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -33,6 +33,7 @@ export {
   resolve,
   sep,
 } from "https://deno.land/std@0.53.0/path/mod.ts";
+export { BufReader } from "https://deno.land/std@0.53.0/io/bufio.ts";
 export { assert } from "https://deno.land/std@0.53.0/testing/asserts.ts";
 
 // 3rd party dependencies


### PR DESCRIPTION
The function created to send static files (oak / send.ts) is cool, but it has a big problem: to send a file, the file is loaded completely into memory. This is a problem because, for example, if there are thousands of simultaneous requests, and there is a 1MB static file, the server will have GB's of memory occupied and will probably die. This is also a problem if there is a large file to send, even with few requests. The modifications I made send the files via Buffer, which solves the problem and makes the function scalable.