### PR TITLE
Fix router to handle next middlewares

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,8 +15,8 @@ export interface Middleware<
 export function compose<
   S extends State = Record<string, any>,
   T extends Context = Context<S>,
->(middleware: Middleware<S, T>[]): (context: T, next?: () => Promise<void>) => Promise<void> {
-  return function composedMiddleware(context: T, next?: () => Promise<void>) {
+>(middleware: Middleware<S, T>[]): (context: T, next?: Middleware<S, T>) => Promise<void> {
+  return function composedMiddleware(context: T, next?: Middleware<S, T>) {
     let index = -1;
 
     function dispatch(i: number): Promise<void> {

--- a/middleware.ts
+++ b/middleware.ts
@@ -15,7 +15,7 @@ export interface Middleware<
 export function compose<
   S extends State = Record<string, any>,
   T extends Context = Context<S>,
->(middleware: Middleware<S, T>[]): (context: T) => Promise<void> {
+>(middleware: Middleware<S, T>[]): (context: T, next?: () => Promise<void>) => Promise<void> {
   return function composedMiddleware(context: T, next?: () => Promise<void>) {
     let index = -1;
 

--- a/middleware_test.ts
+++ b/middleware_test.ts
@@ -88,3 +88,32 @@ test({
     assert(caught instanceof httpErrors.InternalServerError);
   },
 });
+
+test({
+  name: "composed middleware accepts next middleware",
+  async fn() {
+    const callStack: number[] = [];
+    const mockContext = createMockContext();
+
+    const mw0: Middleware = async (context, next) => {
+      assertEquals(typeof next, "function");
+      callStack.push(3);
+      await next();
+    };
+
+    const mw1: Middleware = async (context, next) => {
+      assertEquals(typeof next, "function");
+      callStack.push(1);
+      await next();
+    };
+    const mw2: Middleware = async (context, next) => {
+      assertEquals(typeof next, "function");
+      callStack.push(2);
+      await next();
+    };
+    
+    await compose([mw1, mw2])(mockContext, mw0);
+    assertEquals(callStack, [1, 2, 3]);
+  },
+});
+

--- a/router.ts
+++ b/router.ts
@@ -844,7 +844,7 @@ export class Router<
         ],
         [] as RouterMiddleware[],
       );
-      return compose(chain)(ctx);
+      return compose(chain)(ctx, next);
     };
     dispatch.router = this;
     return dispatch;

--- a/router_test.ts
+++ b/router_test.ts
@@ -675,3 +675,34 @@ test({
     });
   },
 });
+
+
+test({
+  name: "middleware returned from router.routes() passes next",
+  async fn() {
+    const { context } = setup("/foo", "GET");
+
+    const callStack: number[] = [];
+    
+    async function next(){
+      callStack.push(4);
+    }
+
+    const router = new Router();
+    router.get("/", (_context) => {
+      callStack.push(1);
+    });
+    router.get("/foo", async (_context, next) => {
+      callStack.push(2);
+      await next();
+    });
+    router.get("/foo", async (_context, next) => {
+      callStack.push(3);
+      await next();
+    });
+
+    const mw = router.routes();
+    await mw(context, next);
+    assertEquals(callStack, [2, 3, 4]);
+  },
+});


### PR DESCRIPTION
Issue:
Currently, when `router.routes()` middleware is run,
```ts
if (!matches.route) return next();
```
however if any route matched, there is new middleware composed (first chain is calculated).
This new middleware doesn't get `next` as second param, as it should.


