### PR TITLE
Fix for #169 - Change all usage references to use default_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ processing requests with the registered middleware.
 A basic usage, responding to every request with _Hello World!_:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -57,7 +57,7 @@ a context and reference to the "next" method in the stack.
 A more complex example:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -418,7 +418,7 @@ will fire a `"listen"` event, which can be listened for via the
 `.addEventListener()` method. For example:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -442,7 +442,7 @@ an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 Here is an example of using the signal:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -473,7 +473,7 @@ import {
   Application,
   isHttpError,
   Status,
-} from "https://deno.land/x/oak/mod.ts";
+} from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -504,7 +504,7 @@ application. To listen for these errors, you would add an event handler to the
 application instance:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -533,7 +533,7 @@ The following example serves up a _RESTful_ service of a map of books, where
 `http://localhost:8000/book/1` would return the book with ID `"1"`:
 
 ```ts
-import { Application, Router } from "https://deno.land/x/oak/mod.ts";
+import { Application, Router } from "https://deno.land/x/oak@main/mod.ts";
 
 const books = new Map<string, any>();
 books.set("1", {
@@ -573,7 +573,7 @@ file system relative to the root from the requested path.
 A basic usage would look something like this:
 
 ```ts
-import { Application, send } from "https://deno.land/x/oak/mod.ts";
+import { Application, send } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 

--- a/application.ts
+++ b/application.ts
@@ -348,7 +348,7 @@ export class Application<AS extends State = Record<string, any>>
    * Basic usage:
    * 
    * ```ts
-   * const import { Application } from "https://deno.land/x/oak/mod.ts";
+   * const import { Application } from "https://deno.land/x/oak@main/mod.ts";
    * 
    * const app = new Application();
    * 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,7 +25,7 @@ then `.abort()` on the controller when you want the server to close. For
 example:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -54,7 +54,7 @@ interface the "raw" body content.
 In the `ctx.response` call the `.redirect()` method. For example:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 
@@ -70,7 +70,7 @@ the referrer (if the request's `Referrer` header has been set), and the second
 argument can be used to provide a "backup" if there is no referrer. For example:
 
 ```ts
-import { Application, REDIRECT_BACK } from "https://deno.land/x/oak/mod.ts";
+import { Application, REDIRECT_BACK } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ To create a very basic "hello world" server, you would want to create a
 `server.ts` file with the following content:
 
 ```ts
-import { Application } from "https://deno.land/x/oak/mod.ts";
+import { Application } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -15,7 +15,7 @@ The server will respond by keeping open an HTTP connection which will be used
 to send messages:
 
 ```ts
-import { Application, Router } from "https://deno.land/x/oak/mod.ts";
+import { Application, Router } from "https://deno.land/x/oak@main/mod.ts";
 
 const app = new Application();
 const router = new Router();

--- a/response.ts
+++ b/response.ts
@@ -25,7 +25,7 @@ interface ServerResponse {
  * back to the request referrer.  For example:
  * 
  * ```ts
- * import { Application, REDIRECT_BACK } from "https://deno.land/x/oak/mod.ts";
+ * import { Application, REDIRECT_BACK } from "https://deno.land/x/oak@main/mod.ts";
  * 
  * const app = new Application();
  * 

--- a/router.ts
+++ b/router.ts
@@ -800,7 +800,7 @@ export class Router<
    * has been configured to handle.  Typical usage would be something like this:
    * 
    * ```ts
-   * import { Application, Router } from "https://deno.land/x/oak/mod.ts";
+   * import { Application, Router } from "https://deno.land/x/oak@main/mod.ts";
    * 
    * const app = new Application();
    * const router = new Router();

--- a/server_sent_event.ts
+++ b/server_sent_event.ts
@@ -193,7 +193,7 @@ export class ServerSentEventTarget extends EventTarget {
    * connection is kept alive.
    * 
    * ```ts
-   * import { Application } from "https://deno.land/x/oak/mod.ts";
+   * import { Application } from "https://deno.land/x/oak@main/mod.ts";
    * 
    * const app = new Application();
    * 
@@ -226,7 +226,7 @@ export class ServerSentEventTarget extends EventTarget {
    * is cancelled, it will not be sent to the client.
    * 
    * ```ts
-   * import { Application, ServerSentEvent } from "https://deno.land/x/oak/mod.ts";
+   * import { Application, ServerSentEvent } from "https://deno.land/x/oak@main/mod.ts";
    * 
    * const app = new Application();
    * 


### PR DESCRIPTION
Fix for #169 - Change all usage references to use default_version

Following the discussion on https://github.com/denoland/deno_website2/pull/1132 I'm not sure this will be merged soon, so maybe it makes sense to update the documentation for now?

Adding a version to the import is IMHO not a bad behaviour to begin with, even when explicitly specifying `main` as the default version.