### PR TITLE
Make `Application#handleRequest()` be public

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -226,7 +226,7 @@ export class Application<AS extends State = Record<string, any>>
     closing: false,
     closed: false,
     middleware: compose(this.#middleware),
-    server: null
+    server: null,
   }): Promise<void> => {
     const context = new Context(this, request, secure);
     if (!state.closing && !state.closed) {


### PR DESCRIPTION
I want to be in control of the `for await (const req)` loop, so I need
Oak to provide a single function to invoke from within the loop in order
to invoke the middleware in the `Application` instance.

There's some further optimizations that could be done here, like caching
the result of `compose(this.#middleware)`, but I want to get feedback on
this overall approach before continuing further.