### PR TITLE
Make `app.handle()` be an instance function

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -292,10 +292,10 @@ export class Application<AS extends State = Record<string, any>>
    * context gets set to not to respond, then the method resolves with
    * `undefined`, otherwise it resolves with a request that is compatible with
    * `std/http/server`. */
-  async handle(
+  handle = async (
     request: ServerRequest,
     secure = false,
-  ): Promise<ServerResponse | undefined> {
+  ): Promise<ServerResponse | undefined> => {
     if (!this.#middleware.length) {
       throw new TypeError("There is no middleware to process requests.");
     }

--- a/application.ts
+++ b/application.ts
@@ -317,7 +317,7 @@ export class Application<AS extends State = Record<string, any>>
       this.#handleError(context, err);
       throw err;
     }
-  }
+  };
 
   /** Start listening for requests, processing registered middleware on each
    * request.  If the options `.secure` is undefined or `false`, the listening


### PR DESCRIPTION
Currently, exporting the `app.handle` function must be exported with `bind(app)`:

```typescript
export default app.handle.bind(app);
```

With this change, the `app.handle` function may be exported directly as it will already be bound to the `app` instance:

```typescript
export default app.handle;
```