### PR TITLE
breaking: refactor ctx.request.body()

### DIFF
--- a/body.ts
+++ b/body.ts
@@ -1,0 +1,229 @@
+// Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
+
+import { assert } from "./deps.ts";
+import { httpErrors } from "./httpError.ts";
+import { isMediaType } from "./isMediaType.ts";
+import { FormDataReader } from "./multipart.ts";
+import { ServerRequest } from "./types.d.ts";
+
+export type BodyType =
+  | "form"
+  | "form-data"
+  | "json"
+  | "text"
+  | "raw"
+  | "reader"
+  | "undefined";
+
+export type BodyJson = { type: "json"; readonly value: Promise<any> };
+export type BodyForm = {
+  type: "form";
+  readonly value: Promise<URLSearchParams>;
+};
+export type BodyFormData = {
+  type: "form-data";
+  readonly value: FormDataReader;
+};
+export type BodyText = { type: "text"; readonly value: Promise<string> };
+export type BodyRaw = { type: "raw"; readonly value: Promise<Uint8Array> };
+export type BodyUndefined = { type: "undefined"; readonly value: undefined };
+
+export type BodyReader = { type: "reader"; readonly value: Deno.Reader };
+
+export type Body =
+  | BodyJson
+  | BodyForm
+  | BodyFormData
+  | BodyText
+  | BodyRaw
+  | BodyUndefined;
+
+export interface BodyOptions<T extends BodyType = BodyType> {
+  /** Instead of utilizing the content type of the request, return the body
+   * as the type specified. */
+  type?: T;
+  /** A map of extra content types to determine how to parse the body. */
+  contentTypes?: {
+    /** Content types listed here will always return a "raw" Uint8Array. */
+    raw?: string[];
+    /** Content types listed here will be parsed as a JSON string. */
+    json?: string[];
+    /** Content types listed here will be parsed as form data and return
+       * `URLSearchParameters` as the value of the body. */
+    form?: string[];
+    /** Content types listed here will be parsed as from data and return a
+       * `FormDataBody` interface as the value of the body. */
+    formData?: string[];
+    /** Content types listed here will be parsed as text. */
+    text?: string[];
+  };
+}
+
+export interface BodyContentTypes {
+  json?: string[];
+  form?: string[];
+  text?: string[];
+}
+
+const defaultBodyContentTypes = {
+  json: ["json", "application/*+json", "application/csp-report"],
+  form: ["urlencoded"],
+  formData: ["multipart"],
+  text: ["text"],
+};
+
+const decoder = new TextDecoder();
+
+export class RequestBody {
+  #body: Deno.Reader;
+  #formDataReader?: FormDataReader;
+  #has?: boolean;
+  #headers: Headers;
+  #readAllBody?: Promise<Uint8Array>;
+  #type?: "form-data" | "raw" | "reader" | "undefined";
+
+  #valuePromise = () => {
+    return this.#readAllBody ?? (this.#readAllBody = Deno.readAll(this.#body));
+  };
+
+  constructor(request: ServerRequest) {
+    const { body, headers } = request;
+    this.#body = body;
+    this.#headers = headers;
+  }
+
+  get({ type, contentTypes }: BodyOptions): Body | BodyReader {
+    if (type === "reader" && this.#type && this.#type !== "reader") {
+      throw new TypeError(
+        "Body already consumed and cannot be returned as a reader.",
+      );
+    }
+    if (type === "form-data" && this.#type && this.#type !== "form-data") {
+      throw new TypeError(
+        "Body already consumed and cannot be returned as form data.",
+      );
+    }
+    if (this.#type === "reader" && type !== "reader") {
+      throw new TypeError(
+        "Body already consumed as a reader and can only be returned as a reader.",
+      );
+    }
+    if (this.#type === "form-data" && type !== "form-data") {
+      throw new TypeError(
+        "Body already consumed as form data and can only be returned as form data.",
+      );
+    }
+    if (type && contentTypes) {
+      throw new TypeError(
+        `"type" and "contentTypes" cannot be specified at the same time`,
+      );
+    }
+    if (type === "reader") {
+      this.#type = "reader";
+      return { type, value: this.#body };
+    }
+    if (!this.has()) {
+      this.#type = "undefined";
+    } else if (!this.#type) {
+      const encoding = this.#headers.get("content-encoding") ?? "identity";
+      if (encoding !== "identity") {
+        throw new httpErrors.UnsupportedMediaType(
+          `Unsupported content-encoding: ${encoding}`,
+        );
+      }
+    }
+    if (this.#type === "undefined") {
+      if (type) {
+        throw new TypeError(
+          `Body is undefined and cannot be returned as "${type}".`,
+        );
+      }
+      return { type: "undefined", value: undefined };
+    }
+    if (!type) {
+      const contentType = this.#headers.get("content-type");
+      assert(contentType);
+      contentTypes = contentTypes ?? {};
+      const contentTypesJson = [
+        ...defaultBodyContentTypes.json,
+        ...(contentTypes.json ?? []),
+      ];
+      const contentTypesForm = [
+        ...defaultBodyContentTypes.form,
+        ...(contentTypes.form ?? []),
+      ];
+      const contentTypesFormData = [
+        ...defaultBodyContentTypes.formData,
+        ...(contentTypes.formData ?? []),
+      ];
+      const contentTypesText = [
+        ...defaultBodyContentTypes.text,
+        ...(contentTypes.text ?? []),
+      ];
+      if (contentTypes.raw && isMediaType(contentType, contentTypes.raw)) {
+        type = "raw";
+      } else if (isMediaType(contentType, contentTypesJson)) {
+        type = "json";
+      } else if (isMediaType(contentType, contentTypesForm)) {
+        type = "form";
+      } else if (isMediaType(contentType, contentTypesFormData)) {
+        type = "form-data";
+      } else if (isMediaType(contentType, contentTypesText)) {
+        type = "text";
+      } else {
+        type = "raw";
+      }
+    }
+    assert(type);
+    let value: () => Body["value"];
+    switch (type) {
+      case "form":
+        this.#type = "raw";
+        value = async () =>
+          new URLSearchParams(
+            decoder.decode(await this.#valuePromise()).replace(/\+/g, " "),
+          );
+        break;
+      case "form-data":
+        this.#type = "form-data";
+        value = () => {
+          const contentType = this.#headers.get("content-type");
+          assert(contentType);
+          return this.#formDataReader ??
+            (this.#formDataReader = new FormDataReader(
+              contentType,
+              this.#body,
+            ));
+        };
+        break;
+      case "json":
+        this.#type = "raw";
+        value = async () =>
+          JSON.parse(decoder.decode(await this.#valuePromise()));
+        break;
+      case "raw":
+        this.#type = "raw";
+        value = () => this.#valuePromise();
+        break;
+      case "text":
+        this.#type = "raw";
+        value = async () => decoder.decode(await this.#valuePromise());
+        break;
+      default:
+        throw new TypeError(`Invalid body type: "${type}"`);
+    }
+    return {
+      type,
+      get value() {
+        return value();
+      },
+    } as Body;
+  }
+
+  has(): boolean {
+    return this.#has !== undefined
+      ? this.#has
+      : (this.#has = this.#headers.get("transfer-encoding") !== null ||
+        !!parseInt(this.#headers.get("content-length") ?? "", 10));
+  }
+}

--- a/body_test.ts
+++ b/body_test.ts
@@ -1,0 +1,448 @@
+// Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
+
+import { RequestBody } from "./body.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+  test,
+} from "./test_deps.ts";
+import type { ServerRequest } from "./types.d.ts";
+import { decoder } from "https://deno.land/std@0.59.0/encoding/utf8.ts";
+
+const encoder = new TextEncoder();
+
+function createMockBodyReader(body: string): Deno.Reader {
+  const buf = encoder.encode(body);
+  let offset = 0;
+  return {
+    async read(p: Uint8Array): Promise<number | null> {
+      if (offset >= buf.length) {
+        return null;
+      }
+      const chunkSize = Math.min(p.length, buf.length - offset);
+      p.set(buf);
+      offset += chunkSize;
+      return chunkSize;
+    },
+  };
+}
+
+interface MockServerRequestOptions {
+  url?: string;
+  host?: string;
+  body?: string;
+  headerValues?: Record<string, string>;
+  proto?: string;
+  conn?: {
+    remoteAddr: {
+      hostname: string;
+    };
+  };
+}
+
+function createMockServerRequest(
+  {
+    url = "/",
+    host = "localhost",
+    body,
+    headerValues = {},
+    proto = "HTTP/1.1",
+  }: MockServerRequestOptions = {},
+): ServerRequest {
+  const headers = new Headers();
+  headers.set("host", host);
+  for (const [key, value] of Object.entries(headerValues)) {
+    headers.set(key, value);
+  }
+  if (body && body.length && !headers.has("content-length")) {
+    headers.set("content-length", String(body.length));
+  }
+  return {
+    headers,
+    method: "GET",
+    url,
+    proto,
+    body: body && createMockBodyReader(body),
+    async respond() {},
+  } as any;
+}
+
+const multipartContentType =
+  `multipart/form-data; boundary=OAK-SERVER-BOUNDARY`;
+
+const multipartFixture = `
+--OAK-SERVER-BOUNDARY
+Content-Disposition: form-data; name="hello"
+
+world
+--OAK-SERVER-BOUNDARY--
+`;
+
+test({
+  name: "body - form",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `foo=bar&bar=1&baz=qux+%2B+quux`,
+        headerValues: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      },
+    ));
+    assert(requestBody.has());
+    const body = requestBody.get({});
+    assert(body.type === "form");
+    const actual = await body.value;
+    assertEquals(
+      Array.from(actual.entries()),
+      [["foo", "bar"], ["bar", "1"], ["baz", "qux + quux"]],
+    );
+  },
+});
+
+test({
+  name: "body - form-data",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: multipartFixture,
+        headerValues: {
+          "content-type": multipartContentType,
+        },
+      },
+    ));
+    assert(requestBody.has());
+    const body = requestBody.get({});
+    assert(body.type === "form-data");
+    const actual = await body.value.read();
+    assertEquals(actual.fields, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - json",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body: JSON.stringify({ hello: "world" }),
+          headerValues: { "content-type": "application/json" },
+        },
+      ),
+    );
+    assert(requestBody.has());
+    const body = requestBody.get({});
+    assert(body.type === "json");
+    assertEquals(await body.value, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - raw",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `console.log("hello world!");\n`,
+        headerValues: {
+          "content-type": "application/javascript",
+        },
+      },
+    ));
+    assert(requestBody.has());
+    const body = requestBody.get({});
+    assert(body.type === "raw");
+    const actual = await body.value;
+    assertEquals(decoder.decode(actual), `console.log("hello world!");\n`);
+  },
+});
+
+test({
+  name: "body - text",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        { body: "hello", headerValues: { "content-type": "text/plain" } },
+      ),
+    );
+    assert(requestBody.has());
+    const body = requestBody.get({});
+    assert(body.type === "text");
+    assertEquals(await body.value, "hello");
+  },
+});
+
+test({
+  name: "body - undefined",
+  fn() {
+    const requestBody = new RequestBody(createMockServerRequest());
+    assertEquals(requestBody.has(), false);
+    const body = requestBody.get({});
+    assert(body.type === "undefined");
+    assertEquals(body.value, undefined);
+  },
+});
+
+test({
+  name: "body - type: reader",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest({
+      body: "hello world",
+      headerValues: {
+        "content-type": "text/plain",
+      },
+    }));
+    const body = requestBody.get({ type: "reader" });
+    assert(body.type === "reader");
+    const actual = await Deno.readAll(body.value);
+    assertEquals(decoder.decode(actual), "hello world");
+  },
+});
+
+test({
+  name: "body - type: form",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `foo=bar&bar=1&baz=qux+%2B+quux`,
+        headerValues: {
+          "Content-Type": "application/javascript",
+        },
+      },
+    ));
+    const body = requestBody.get({ type: "form" });
+    assert(body.type === "form");
+    const actual = await body.value;
+    assertEquals(
+      Array.from(actual.entries()),
+      [["foo", "bar"], ["bar", "1"], ["baz", "qux + quux"]],
+    );
+  },
+});
+
+test({
+  name: "body - type: form-data",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: multipartFixture,
+        headerValues: {
+          "content-type":
+            "application/javascript; boundary=OAK-SERVER-BOUNDARY",
+        },
+      },
+    ));
+    const body = requestBody.get({ type: "form-data" });
+    assert(body.type === "form-data");
+    const actual = await body.value.read();
+    assertEquals(actual.fields, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - type: raw",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `console.log("hello world!");\n`,
+        headerValues: {
+          "content-type": "text/plain",
+        },
+      },
+    ));
+    const body = requestBody.get({ type: "raw" });
+    assert(body.type === "raw");
+    const actual = await body.value;
+    assertEquals(decoder.decode(actual), `console.log("hello world!");\n`);
+  },
+});
+
+test({
+  name: "body - type: json",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body: JSON.stringify({ hello: "world" }),
+          headerValues: { "content-type": "application/javascript" },
+        },
+      ),
+    );
+    const body = requestBody.get({ type: "json" });
+    assert(body.type === "json");
+    assertEquals(await body.value, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - type: text",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body: "hello",
+          headerValues: { "content-type": "application/javascript" },
+        },
+      ),
+    );
+    const body = requestBody.get({ type: "text" });
+    assert(body.type === "text");
+    assertEquals(await body.value, "hello");
+  },
+});
+
+test({
+  name: "body - type - body undefined",
+  fn() {
+    const requestBody = new RequestBody(createMockServerRequest());
+    assertEquals(requestBody.has(), false);
+    assertThrows(
+      () => {
+        requestBody.get({ type: "text" });
+      },
+      TypeError,
+      `Body is undefined and cannot be returned as "text".`,
+    );
+  },
+});
+
+test({
+  name: "body - contentTypes: form",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `foo=bar&bar=1&baz=qux+%2B+quux`,
+        headerValues: {
+          "Content-Type": "application/javascript",
+        },
+      },
+    ));
+    const body = requestBody.get(
+      { contentTypes: { form: ["application/javascript"] } },
+    );
+    assert(body.type === "form");
+    const actual = await body.value;
+    assertEquals(
+      Array.from(actual.entries()),
+      [["foo", "bar"], ["bar", "1"], ["baz", "qux + quux"]],
+    );
+  },
+});
+
+test({
+  name: "body - contentTypes: form-data",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: multipartFixture,
+        headerValues: {
+          "content-type":
+            "application/javascript; boundary=OAK-SERVER-BOUNDARY",
+        },
+      },
+    ));
+    const body = requestBody.get(
+      { contentTypes: { formData: ["application/javascript"] } },
+    );
+    assert(body.type === "form-data");
+    const actual = await body.value.read();
+    assertEquals(actual.fields, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - contentTypes: raw",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `console.log("hello world!");\n`,
+        headerValues: {
+          "content-type": "text/plain",
+        },
+      },
+    ));
+    const body = requestBody.get({ contentTypes: { raw: ["text/plain"] } });
+    assert(body.type === "raw");
+    const actual = await body.value;
+    assertEquals(decoder.decode(actual), `console.log("hello world!");\n`);
+  },
+});
+
+test({
+  name: "body - contentTypes: json",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body: JSON.stringify({ hello: "world" }),
+          headerValues: { "content-type": "application/javascript" },
+        },
+      ),
+    );
+    const body = requestBody.get(
+      { contentTypes: { json: ["application/javascript"] } },
+    );
+    assert(body.type === "json");
+    assertEquals(await body.value, { hello: "world" });
+  },
+});
+
+test({
+  name: "body - contentTypes: text",
+  async fn() {
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body: "hello",
+          headerValues: { "content-type": "application/javascript" },
+        },
+      ),
+    );
+    const body = requestBody.get(
+      { contentTypes: { text: ["application/javascript"] } },
+    );
+    assert(body.type === "text");
+    assertEquals(await body.value, "hello");
+  },
+});
+
+test({
+  name: "body - multiple gets memoized",
+  fn() {
+    const requestBody = new RequestBody(createMockServerRequest(
+      {
+        body: `console.log("hello world!");\n`,
+        headerValues: {
+          "content-type": "application/javascript",
+        },
+      },
+    ));
+    const a = requestBody.get({});
+    const b = requestBody.get({});
+    assertStrictEquals(a.type, b.type);
+    assertStrictEquals(a.value, b.value);
+    assert(a !== b);
+  },
+});
+
+test({
+  name: "body - can get different types",
+  async fn() {
+    const body = JSON.stringify({ hello: "world" });
+    const requestBody = new RequestBody(
+      createMockServerRequest(
+        {
+          body,
+          headerValues: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const textBody = requestBody.get({ type: "text" });
+    assert(textBody.type === "text");
+    assertEquals(await textBody.value, body);
+    const bodyJson = requestBody.get({});
+    assert(bodyJson.type === "json");
+    assertEquals(await bodyJson.value, { hello: "world" });
+  },
+});

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -43,7 +43,7 @@ console.log("Server closed.");
 
 ## How to get access to the "raw" request body?
 
-When requesting a body, use `await ctx.request.body({ asReader: true })`. This
+When requesting a body, use `ctx.request.body({ type: "reader" })`. This
 will resolve with the
 [`Deno.Reader`](https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts#Deno.Reader)
 interface in the `value` property of the response. You can then read from this

--- a/examples/echoServer.ts
+++ b/examples/echoServer.ts
@@ -1,3 +1,8 @@
+/*
+ * This is an example of a server which will take whatever the request is and
+ * respond back with information about the request.
+ */
+
 import {
   green,
   cyan,
@@ -29,36 +34,49 @@ app.use(async (ctx, next) => {
   ctx.response.headers.set("X-Response-Time", `${ms}ms`);
 });
 
+const decoder = new TextDecoder();
+
 app.use(async (ctx) => {
   if (ctx.request.hasBody) {
-    const body = await ctx.request.body();
-    if (body) {
-      ctx.response.body = `<!DOCTYPE html><html><body>
+    const body = ctx.request.body();
+    ctx.response.body = `<!DOCTYPE html><html><body>
           <h1>Body type: "${body.type}"</h1>`;
-      switch (body.type) {
-        case "form":
-          ctx.response.body +=
-            `<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>`;
-          for (const [key, value] of body.value) {
-            ctx.response.body += `<tr><td>${key}</td><td>${value}</td></tr>`;
-          }
-          ctx.response.body += `</tbody></table>`;
-        case "text":
-          ctx.response.body += `<pre>${body.value}</pre>`;
-          break;
-        case "json":
-          ctx.response.body += `<pre>${
-            JSON.stringify(body.value, undefined, "  ")
-          }</pre>`;
-          break;
-        case "raw":
-          ctx.response.body += `<pre>${String(body.value)}</pre>`;
-          break;
-        default:
-          ctx.response.body += `<p><strong>Body is Undefined</strong></p>`;
-      }
-      ctx.response.body += `</body></html>`;
+    switch (body.type) {
+      case "form":
+        ctx.response.body +=
+          `<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>`;
+        for (const [key, value] of await body.value) {
+          ctx.response.body += `<tr><td>${key}</td><td>${value}</td></tr>`;
+        }
+        ctx.response.body += `</tbody></table>`;
+        break;
+      case "form-data":
+        const { files, fields } = await body.value.read();
+        ctx.response.body +=
+          `<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>`;
+        for (const [key, value] of Object.entries(fields)) {
+          ctx.response.body += `<tr><td>${key}</td><td>${value}</td></tr>`;
+        }
+        ctx.response.body += `</tbody></table>`;
+        break;
+      case "text":
+        ctx.response.body += `<pre>${body.value}</pre>`;
+        break;
+      case "json":
+        ctx.response.body += `<pre>${
+          JSON.stringify(await body.value, undefined, "  ")
+        }</pre>`;
+        break;
+      case "raw":
+        ctx.response.body += `<h2>Content Type: "${
+          ctx.request.headers.get("content-type")
+        }"</h2>`;
+        ctx.response.body += `<pre>${decoder.decode(await body.value)}</pre>`;
+        break;
+      default:
+        ctx.response.body += `<p><strong>Body is Undefined</strong></p>`;
     }
+    ctx.response.body += `</body></html>`;
   } else {
     ctx.response.body =
       `<!DOCTYPE html><html><body><h1>No Body</h1></body></html>`;

--- a/examples/routingServer.ts
+++ b/examples/routingServer.ts
@@ -52,13 +52,13 @@ router
     if (!context.request.hasBody) {
       context.throw(Status.BadRequest, "Bad Request");
     }
-    const body = await context.request.body();
+    const body = context.request.body();
     let book: Partial<Book> | undefined;
     if (body.type === "json") {
-      book = body.value;
+      book = await body.value;
     } else if (body.type === "form") {
       book = {};
-      for (const [key, value] of body.value) {
+      for (const [key, value] of await body.value) {
         book[key as keyof Book] = value;
       }
     } else if (body.type === "form-data") {

--- a/examples/staticServer.ts
+++ b/examples/staticServer.ts
@@ -1,3 +1,8 @@
+/*
+ * This is an example of a server that will serve static content out of the
+ * $CWD/examples/static path.
+ */
+
 import {
   green,
   cyan,

--- a/mod.ts
+++ b/mod.ts
@@ -8,6 +8,18 @@ export type {
   ListenOptionsTls,
   State,
 } from "./application.ts";
+export type {
+  Body,
+  BodyForm,
+  BodyFormData,
+  BodyJson,
+  BodyOptions,
+  BodyRaw,
+  BodyReader,
+  BodyText,
+  BodyType,
+  BodyUndefined,
+} from "./body.ts";
 export { Context } from "./context.ts";
 export type { ContextSendOptions } from "./context.ts";
 export * as helpers from "./helpers.ts";
@@ -24,19 +36,6 @@ export type {
 } from "./multipart.ts";
 
 export { Request } from "./request.ts";
-export type {
-  Body,
-  BodyForm,
-  BodyFormData,
-  BodyJson,
-  BodyOptions,
-  BodyOptionsAsReader,
-  BodyRaw,
-  BodyReader,
-  BodyText,
-  BodyType,
-  BodyUndefined,
-} from "./request.ts";
 export { Response, REDIRECT_BACK } from "./response.ts";
 export { Router } from "./router.ts";
 export type {

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the oak authors. All rights reserved. MIT license.
 
-export const test = Deno.test;
+export const { test } = Deno;
 
 export { BufReader, BufWriter } from "https://deno.land/std@0.59.0/io/bufio.ts";
 export { StringReader } from "https://deno.land/std@0.59.0/io/readers.ts";


### PR DESCRIPTION
This PR reworks `ctx.request.body()` in a breaking change way.

Previously, `.body()` returned a promise which resolved with an object containing the properties `type` and `value`.  Now, it simply returns the object with the properties `type` and `value`, and the type of the value of `value` will sometimes be a promise, or sometimes be another asynchronous type of object (`Deno.Reader` or `FormDataReader`), or `undefined` in the case where there is no body.

Also, the options have changed, to where previously there was an option flag `asReader` which when set to true returned a `"reader"` type body.  Now there is a `type` property which takes one of `"reader"`, `"form"`, `"form-data"`, `"json"`, `"raw"`, or `"text"`, and the body will be returned with that type.