### PR TITLE
ci: upgrade deno action to v2

### DIFF
--- a/.github/workflows/oak-ci.yml
+++ b/.github/workflows/oak-ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: download deno
-        uses: denolib/setup-deno@master
+        uses: denolib/setup-deno@v2
         with:
           deno-version: v1.2.0
       - name: check format


### PR DESCRIPTION
BTW. We can add a scheduled task to test v1.x version regularly