### PR TITLE
fix: ensure server closed on abort when no requests in flight

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -367,7 +367,7 @@ export class Application<AS extends State = Record<string, any>>
     };
     if (signal) {
       signal.addEventListener("abort", () => {
-        if (!state.handling) {
+        if (!state.handling.size) {
           server.close();
           state.closed = true;
         }


### PR DESCRIPTION
Addresses https://github.com/oakserver/oak/issues/206.

This PR amends the abort signal event handling to check against the `size` property of the `state.handling` `Set` rather than against the existence of the `Set` (which will always be truthy).

Updated existing signal test to use the created `AbortController`, and added a second test to cover the scenario where there are no requests in-flight to test this fix.

Changes:

* fix: ensure server closed on abort when no requests in flight
* test: fix current signal test
* test: add signal test for scenario with no requests in flight