### PR TITLE
fix links to other oakserver github projects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,9 @@ and middleware router inspired by
 
 - [deno doc for oak](https://doc.deno.land/https/deno.land/x/oak/mod.ts)
 - [Frequently Asked Questions](./FAQ)
-- [Awesome oak](https://oakserver.github.io/awesome-oak/) - Community resources
+- [Awesome oak](https://github.com/oakserver/awesome-oak) - Community resources
   for oak.
-- [oak_middleware](https://oakserver.github.io/middleware/) - A collection of
+- [oak_middleware](https://github.com/oakserver/middleware) - A collection of
   middleware maintained by us.
 - [Getting Started](#getting-started)
 - [Server Sent Events](./sse)


### PR DESCRIPTION
The links to awsome-oak and middleware were broken. The should work now.