### PR TITLE
Do not require CWD permissions to serve static files; additional tests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -23,7 +23,6 @@ export {
   isAbsolute,
   normalize,
   parse,
-  resolve,
   sep,
 } from "https://deno.land/std@0.61.0/path/mod.ts";
 export { assert } from "https://deno.land/std@0.61.0/testing/asserts.ts";

--- a/fixtures/.test.json
+++ b/fixtures/.test.json
@@ -1,0 +1,3 @@
+{
+  "hidden": "file"
+}

--- a/fixtures/.test/test.json
+++ b/fixtures/.test/test.json
@@ -1,0 +1,3 @@
+{
+  "inside": "hidden"
+}

--- a/send.ts
+++ b/send.ts
@@ -48,9 +48,9 @@ export interface SendOptions {
 }
 
 function isHidden(path: string) {
-  const pathArr = path.split('/');
+  const pathArr = path.split("/");
   for (const segment of pathArr) {
-    if (segment[0] === "." && segment !== '.' && segment !== '..') {
+    if (segment[0] === "." && segment !== "." && segment !== "..") {
       return true;
     }
     return false;
@@ -67,7 +67,7 @@ async function exists(path: string): Promise<boolean> {
 
 /** Asynchronously fulfill a response with a file from the local file
  * system.
- * 
+ *
  * Requires Deno read permission for the `root` directory. */
 export async function send(
   { request, response }: Context<any>,
@@ -92,7 +92,7 @@ export async function send(
   }
 
   if (!hidden && isHidden(path)) {
-    throw createHttpError(403)
+    throw createHttpError(403);
   }
 
   path = resolvePath(root, path);

--- a/send.ts
+++ b/send.ts
@@ -47,10 +47,10 @@ export interface SendOptions {
   root: string;
 }
 
-function isHidden(root: string, path: string) {
-  const pathArr = path.substr(root.length).split(sep);
+function isHidden(path: string) {
+  const pathArr = path.split('/');
   for (const segment of pathArr) {
-    if (segment[0] === ".") {
+    if (segment[0] === "." && segment !== '.' && segment !== '..') {
       return true;
     }
     return false;
@@ -68,7 +68,7 @@ async function exists(path: string): Promise<boolean> {
 /** Asynchronously fulfill a response with a file from the local file
  * system.
  * 
- * Requires Deno read permission. */
+ * Requires Deno read permission for the `root` directory. */
 export async function send(
   { request, response }: Context<any>,
   path: string,
@@ -91,11 +91,11 @@ export async function send(
     path += index;
   }
 
-  path = resolvePath(root, path);
-
-  if (!hidden && isHidden(root, path)) {
-    return;
+  if (!hidden && isHidden(path)) {
+    throw createHttpError(403)
   }
+
+  path = resolvePath(root, path);
 
   let encodingExt = "";
   if (

--- a/send_test.ts
+++ b/send_test.ts
@@ -274,7 +274,7 @@ test({
     const fixture = await Deno.readFile("./fixtures/.test.json");
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
-      hidden: true
+      hidden: true,
     });
     const serverResponse = context.response.toServerResponse();
     const bodyReader = (await serverResponse).body;

--- a/send_test.ts
+++ b/send_test.ts
@@ -313,3 +313,67 @@ test({
     context.response.destroy();
   },
 });
+
+test({
+  name: "send url: /../file sends /file",
+  async fn() {
+    const { context } = setup("/../test.json");
+    const fixture = await Deno.readFile("./fixtures/test.json");
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    const serverResponse = context.response.toServerResponse();
+    const bodyReader = (await serverResponse).body;
+    assert(isDenoReader(bodyReader));
+    const body = await Deno.readAll(bodyReader);
+    assertEquals(body, fixture);
+    assertEquals(context.response.type, ".json");
+    assertStrictEquals(context.response.headers.get("content-encoding"), null);
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+    context.response.destroy();
+  },
+});
+
+test({
+  name: "send path: /../file throws 403",
+  async fn() {
+    const { context } = setup("/../test.json");
+    encodingsAccepted = "identity";
+    let didThrow = false;
+    try {
+      await send(context, "/../test.json", {
+        root: "./fixtures",
+      });
+    } catch (e) {
+      assert(e instanceof httpErrors.Forbidden);
+      didThrow = true;
+    }
+    assert(didThrow);
+  },
+});
+
+test({
+  name: "send allows .. in root",
+  async fn() {
+    const { context } = setup("/test.json");
+    const fixture = await Deno.readFile("./fixtures/test.json");
+    await send(context, context.request.url.pathname, {
+      root: "../oak/fixtures",
+    });
+    const serverResponse = context.response.toServerResponse();
+    const bodyReader = (await serverResponse).body;
+    assert(isDenoReader(bodyReader));
+    const body = await Deno.readAll(bodyReader);
+    assertEquals(body, fixture);
+    assertEquals(context.response.type, ".json");
+    assertStrictEquals(context.response.headers.get("content-encoding"), null);
+    assertEquals(
+      context.response.headers.get("content-length"),
+      String(fixture.length),
+    );
+    context.response.destroy();
+  },
+});

--- a/util.ts
+++ b/util.ts
@@ -171,7 +171,7 @@ export function resolvePath(rootPath: string, relativePath?: string): string {
   // root is optional, similar to root.resolve
   if (arguments.length === 1) {
     path = rootPath;
-    root = Deno.cwd();
+    root = '.';
   }
 
   if (path == null) {
@@ -194,5 +194,5 @@ export function resolvePath(rootPath: string, relativePath?: string): string {
   }
 
   // join the relative path
-  return normalize(join(resolve(root), path));
+  return normalize(join(root, path));
 }

--- a/util.ts
+++ b/util.ts
@@ -171,7 +171,7 @@ export function resolvePath(rootPath: string, relativePath?: string): string {
   // root is optional, similar to root.resolve
   if (arguments.length === 1) {
     path = rootPath;
-    root = '.';
+    root = ".";
   }
 
   if (path == null) {

--- a/util.ts
+++ b/util.ts
@@ -4,7 +4,6 @@ import {
   isAbsolute,
   join,
   normalize,
-  resolve,
   sep,
   Sha1,
   Status,

--- a/util_test.ts
+++ b/util_test.ts
@@ -19,7 +19,7 @@ test({
   fn() {
     assertEquals(
       resolvePath("./foo/bar").replace(/\\/g, "/"),
-      `${Deno.cwd().replace(/\\/g, "/")}/foo/bar`,
+      `foo/bar`,
     );
   },
 });


### PR DESCRIPTION
It struck me as very slightly insecure to require `--allow-read=.` for `send` to work; in principle, a vulnerability in my code could expose secrets without requiring a further Deno exploit. This PR removes that requirement.

Before:
```
$ deno test --allow-read=./fixtures,$TEMP --allow-write=$TEMP
...
PermissionDenied: read access to <CWD>, run again with the --allow-read flag
...
test result: FAILED. 254 passed; 14 failed; 0 ignored; 0 measured; 0 filtered out (477ms)
```

After:
```
$ deno test --allow-read=./fixtures,$TEMP --allow-write=$TEMP
...
test result: ok. 275 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (511ms)
```

### Example
```
project/
  server.ts
  secrets.ts
  public/
    index.html
    ...

$ deno run --allow-read=public server.ts
...
PermissionDenied: read access to <CWD>, run again with the --allow-read flag
```

But I don't want to `--allow-read=.` -- that would give my code (and dependencies) file-level access to `secrets.ts`, which previously was only accessible to `deno` itself using the narrow `import` API.

### What's changed

Digging into it, `send` only requires CWD permissions because it uses `resolvePath` to sanitize its input. That function is adapted from [pillarjs/resolve-path](/pillarjs/resolve-path), which is a node package. I'm sure that made sense to do at the time, but Deno and node don't have the same security model: Deno can follow relative paths implicitly without exposing read permissions to the user.

So I changed `Deno.cwd()` to simply `.`, and removed the use of std's `resolve` entirely. Of course this means that `resolvePath` is not really "resolving" anymore, just sanitizing and normalizing. AFAICT it's not a big deal because `resolvePath` is only used in this context, but it's something to note.

In any event, I'm now able to explicitly `--allow-read` only for the static files, and Deno itself will backstop the security of the `send` API.

### Changes to hidden files, other tests

There are a few additional tests in this PR. I think that changing `resolvePath` broke detection of hidden files by `send`, but there were no tests for that. So I added some, and made them pass by changing `isHidden` to test the input path rather than the resolved file path (which is no longer really "resolved"). In doing so I noticed that `send` was serving a blank `200` for hidden files; I changed that to throw a bare `403` instead. (You could argue a 404 is more appropriate?)

As I've implemented it, you're able to use both `..` and `.hidden` in the provided `root` path, on the assumption that the root should typically be static, but not within the dynamic `path` parameter. That supports this use case:

```
project/
  client/
    index.html
    index.js
  server/
    server.ts
    secrets.ts

$ cd server
$ deno run --allow-read=../client server.ts
```
The server doesn't own the client files; it just serves them.

It's worth noting that `resolvePath` *should* throw 403 on `..` paths, if you managed to send one in, but in practice something earlier in the framework is normalizing them out of the URL, so you'll probably get a 404 or a different file instead. You'll only see the 403 if you pass in a path besides `request.url`. There's a test documenting that too.