### PR TITLE
Update to Deno 1.4.4, std 0.73.0, media_types 2.5.1

### DIFF
--- a/.github/workflows/oak-ci.yml
+++ b/.github/workflows/oak-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: download deno
         uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.4.2
+          deno-version: v1.4.4
       - name: check format
         if: matrix.os == 'ubuntu-latest'
         run: deno fmt --check

--- a/application.ts
+++ b/application.ts
@@ -16,8 +16,7 @@ import type {
   ServerResponse,
   ServeTls,
 } from "./types.d.ts";
-import { reset } from "https://deno.land/std@0.71.0/fmt/colors.ts";
-import { resolve } from "https://deno.land/std@0.71.0/path/win32.ts";
+
 export interface ListenOptionsBase {
   hostname?: string;
   port: number;

--- a/deps.ts
+++ b/deps.ts
@@ -40,9 +40,9 @@ export {
   compile,
   parse as pathParse,
   pathToRegexp,
-} from "https://raw.githubusercontent.com/pillarjs/path-to-regexp/v6.1.0/src/index.ts";
+} from "https://deno.land/x/path_to_regexp@v6.2.0/index.ts";
 export type {
   Key,
   ParseOptions,
   TokensToRegexpOptions,
-} from "https://raw.githubusercontent.com/pillarjs/path-to-regexp/v6.1.0/src/index.ts";
+} from "https://deno.land/x/path_to_regexp@v6.2.0/index.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -4,15 +4,15 @@
 
 // `std` dependencies
 
-export { copyBytes, equal } from "https://deno.land/std@0.71.0/bytes/mod.ts";
-export { Sha1 } from "https://deno.land/std@0.71.0/hash/sha1.ts";
-export { HmacSha256 } from "https://deno.land/std@0.71.0/hash/sha256.ts";
-export { serve, serveTLS } from "https://deno.land/std@0.71.0/http/server.ts";
+export { copyBytes, equal } from "https://deno.land/std@0.73.0/bytes/mod.ts";
+export { Sha1 } from "https://deno.land/std@0.73.0/hash/sha1.ts";
+export { HmacSha256 } from "https://deno.land/std@0.73.0/hash/sha256.ts";
+export { serve, serveTLS } from "https://deno.land/std@0.73.0/http/server.ts";
 export {
   Status,
   STATUS_TEXT,
-} from "https://deno.land/std@0.71.0/http/http_status.ts";
-export { BufReader, BufWriter } from "https://deno.land/std@0.71.0/io/bufio.ts";
+} from "https://deno.land/std@0.73.0/http/http_status.ts";
+export { BufReader, BufWriter } from "https://deno.land/std@0.73.0/io/bufio.ts";
 export {
   basename,
   extname,
@@ -21,13 +21,13 @@ export {
   normalize,
   parse,
   sep,
-} from "https://deno.land/std@0.71.0/path/mod.ts";
-export { assert } from "https://deno.land/std@0.71.0/testing/asserts.ts";
+} from "https://deno.land/std@0.73.0/path/mod.ts";
+export { assert } from "https://deno.land/std@0.73.0/testing/asserts.ts";
 export {
   acceptable,
   acceptWebSocket,
-} from "https://deno.land/std@0.71.0/ws/mod.ts";
-export type { WebSocket } from "https://deno.land/std@0.71.0/ws/mod.ts";
+} from "https://deno.land/std@0.73.0/ws/mod.ts";
+export type { WebSocket } from "https://deno.land/std@0.73.0/ws/mod.ts";
 
 // 3rd party dependencies
 
@@ -35,7 +35,7 @@ export {
   contentType,
   extension,
   lookup,
-} from "https://deno.land/x/media_types@v2.5.0/mod.ts";
+} from "https://deno.land/x/media_types@v2.5.1/mod.ts";
 export {
   compile,
   parse as pathParse,

--- a/examples/closeServer.ts
+++ b/examples/closeServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application, Context, Router, Status } from "../mod.ts";
 

--- a/examples/cookieServer.ts
+++ b/examples/cookieServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/echoServer.ts
+++ b/examples/echoServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/httpsServer.ts
+++ b/examples/httpsServer.ts
@@ -9,7 +9,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/readerServer.ts
+++ b/examples/readerServer.ts
@@ -4,8 +4,8 @@
  */
 
 // Importing some console colors
-import { bold, yellow } from "https://deno.land/std@0.71.0/fmt/colors.ts";
-import { StringReader } from "https://deno.land/std@0.71.0/io/readers.ts";
+import { bold, yellow } from "https://deno.land/std@0.73.0/fmt/colors.ts";
+import { StringReader } from "https://deno.land/std@0.73.0/io/readers.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/routingServer.ts
+++ b/examples/routingServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import {
   Application,

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -9,7 +9,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/sseServer.ts
+++ b/examples/sseServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import {
   Application,

--- a/examples/staticServer.ts
+++ b/examples/staticServer.ts
@@ -9,7 +9,7 @@ import {
   green,
   red,
   yellow,
-} from "https://deno.land/std@0.71.0/fmt/colors.ts";
+} from "https://deno.land/std@0.73.0/fmt/colors.ts";
 
 import { Application, HttpError, Status } from "../mod.ts";
 

--- a/request_test.ts
+++ b/request_test.ts
@@ -2,10 +2,15 @@
 
 // deno-lint-ignore-file
 
-import { assert, assertEquals, assertStrictEquals, test } from "./test_deps.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrowsAsync,
+  test,
+} from "./test_deps.ts";
 import { Request } from "./request.ts";
 import type { ServerRequest } from "./types.d.ts";
-import { assertThrowsAsync } from "https://deno.land/std@0.71.0/testing/asserts.ts";
 const encoder = new TextEncoder();
 
 function createMockBodyReader(body: string): Deno.Reader {

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -2,13 +2,13 @@
 
 export const { test } = Deno;
 
-export { BufReader, BufWriter } from "https://deno.land/std@0.71.0/io/bufio.ts";
-export { StringReader } from "https://deno.land/std@0.71.0/io/readers.ts";
-export { StringWriter } from "https://deno.land/std@0.71.0/io/writers.ts";
+export { BufReader, BufWriter } from "https://deno.land/std@0.73.0/io/bufio.ts";
+export { StringReader } from "https://deno.land/std@0.73.0/io/readers.ts";
+export { StringWriter } from "https://deno.land/std@0.73.0/io/writers.ts";
 export {
   assert,
   assertEquals,
   assertStrictEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+} from "https://deno.land/std@0.73.0/testing/asserts.ts";


### PR DESCRIPTION
Also moves to path_to_regexp (and updates to v6.3.0) on deno.land/x for better deduplication across modules.