### PR TITLE
Update to Deno 1.5.4/std 0.79.0

### DIFF
--- a/.github/workflows/oak-ci.yml
+++ b/.github/workflows/oak-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: download deno
         uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.5.2
+          deno-version: v1.5.4
       - name: check format
         if: matrix.os == 'ubuntu-latest'
         run: deno fmt --check

--- a/deps.ts
+++ b/deps.ts
@@ -4,15 +4,15 @@
 
 // `std` dependencies
 
-export { copyBytes, equal } from "https://deno.land/std@0.77.0/bytes/mod.ts";
-export { Sha1 } from "https://deno.land/std@0.77.0/hash/sha1.ts";
-export { HmacSha256 } from "https://deno.land/std@0.77.0/hash/sha256.ts";
-export { serve, serveTLS } from "https://deno.land/std@0.77.0/http/server.ts";
+export { copyBytes, equal } from "https://deno.land/std@0.79.0/bytes/mod.ts";
+export { Sha1 } from "https://deno.land/std@0.79.0/hash/sha1.ts";
+export { HmacSha256 } from "https://deno.land/std@0.79.0/hash/sha256.ts";
+export { serve, serveTLS } from "https://deno.land/std@0.79.0/http/server.ts";
 export {
   Status,
   STATUS_TEXT,
-} from "https://deno.land/std@0.77.0/http/http_status.ts";
-export { BufReader, BufWriter } from "https://deno.land/std@0.77.0/io/bufio.ts";
+} from "https://deno.land/std@0.79.0/http/http_status.ts";
+export { BufReader, BufWriter } from "https://deno.land/std@0.79.0/io/bufio.ts";
 export {
   basename,
   extname,
@@ -21,13 +21,13 @@ export {
   normalize,
   parse,
   sep,
-} from "https://deno.land/std@0.77.0/path/mod.ts";
-export { assert } from "https://deno.land/std@0.77.0/testing/asserts.ts";
+} from "https://deno.land/std@0.79.0/path/mod.ts";
+export { assert } from "https://deno.land/std@0.79.0/testing/asserts.ts";
 export {
   acceptable,
   acceptWebSocket,
-} from "https://deno.land/std@0.77.0/ws/mod.ts";
-export type { WebSocket } from "https://deno.land/std@0.77.0/ws/mod.ts";
+} from "https://deno.land/std@0.79.0/ws/mod.ts";
+export type { WebSocket } from "https://deno.land/std@0.79.0/ws/mod.ts";
 
 // 3rd party dependencies
 

--- a/examples/closeServer.ts
+++ b/examples/closeServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application, Context, Router, Status } from "../mod.ts";
 

--- a/examples/cookieServer.ts
+++ b/examples/cookieServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/echoServer.ts
+++ b/examples/echoServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/httpsServer.ts
+++ b/examples/httpsServer.ts
@@ -9,7 +9,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/readerServer.ts
+++ b/examples/readerServer.ts
@@ -4,8 +4,8 @@
  */
 
 // Importing some console colors
-import { bold, yellow } from "https://deno.land/std@0.77.0/fmt/colors.ts";
-import { StringReader } from "https://deno.land/std@0.77.0/io/readers.ts";
+import { bold, yellow } from "https://deno.land/std@0.79.0/fmt/colors.ts";
+import { StringReader } from "https://deno.land/std@0.79.0/io/readers.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/routingServer.ts
+++ b/examples/routingServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import {
   Application,

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -9,7 +9,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application } from "../mod.ts";
 

--- a/examples/sseServer.ts
+++ b/examples/sseServer.ts
@@ -8,7 +8,7 @@ import {
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import {
   Application,

--- a/examples/staticServer.ts
+++ b/examples/staticServer.ts
@@ -9,7 +9,7 @@ import {
   green,
   red,
   yellow,
-} from "https://deno.land/std@0.77.0/fmt/colors.ts";
+} from "https://deno.land/std@0.79.0/fmt/colors.ts";
 
 import { Application, HttpError, Status } from "../mod.ts";
 

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -2,13 +2,13 @@
 
 export const { test } = Deno;
 
-export { BufReader, BufWriter } from "https://deno.land/std@0.77.0/io/bufio.ts";
-export { StringReader } from "https://deno.land/std@0.77.0/io/readers.ts";
-export { StringWriter } from "https://deno.land/std@0.77.0/io/writers.ts";
+export { BufReader, BufWriter } from "https://deno.land/std@0.79.0/io/bufio.ts";
+export { StringReader } from "https://deno.land/std@0.79.0/io/readers.ts";
+export { StringWriter } from "https://deno.land/std@0.79.0/io/writers.ts";
 export {
   assert,
   assertEquals,
   assertStrictEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.77.0/testing/asserts.ts";
+} from "https://deno.land/std@0.79.0/testing/asserts.ts";


### PR DESCRIPTION
Hello,
Just updating std to 0.79.0.
All tests passed.
I need the last update on std/http [https://github.com/denoland/deno/pull/8365](https://github.com/denoland/deno/pull/8365)
Because my servers are down afters 6-12hours.
See => [https://github.com/denoland/deno/issues/8107](https://github.com/denoland/deno/issues/8107)