### PR TITLE
Add support for "If-Modified-Since" header in send()

### DIFF
--- a/send.ts
+++ b/send.ts
@@ -151,9 +151,15 @@ export async function send(
   }
 
   response.headers.set("Content-Length", String(stats.size));
-  if (!response.headers.has("Last-Modified") && stats.mtime) {
+
+  let mtime: Date | null = null;
+  if (response.headers.has("Last-Modified")) {
+    mtime = new Date(response.headers.get("Last-Modified")!);
+  } else if (stats.mtime) {
+    mtime = stats.mtime;
     response.headers.set("Last-Modified", stats.mtime.toUTCString());
   }
+
   if (!response.headers.has("Cache-Control")) {
     const directives = [`max-age=${(maxage / 1000) | 0}`];
     if (immutable) {
@@ -166,6 +172,15 @@ export async function send(
       ? extname(basename(path, encodingExt))
       : extname(path);
   }
+
+  if (request.headers.has("If-Modified-Since") && mtime) {
+    const ifModifiedSince = new Date(request.headers.get("If-Modified-Since")!);
+    if (ifModifiedSince.getTime() < mtime.getTime()) {
+      response.status = 304;
+      return path;
+    }
+  }
+
   const file = await Deno.open(path, { read: true });
   response.addResource(file.rid);
   response.body = file;

--- a/send.ts
+++ b/send.ts
@@ -150,8 +150,6 @@ export async function send(
     throw createHttpError(500, err.message);
   }
 
-  response.headers.set("Content-Length", String(stats.size));
-
   let mtime: Date | null = null;
   if (response.headers.has("Last-Modified")) {
     mtime = new Date(response.headers.get("Last-Modified")!);
@@ -180,6 +178,8 @@ export async function send(
       return path;
     }
   }
+
+  response.headers.set("Content-Length", String(stats.size));
 
   const file = await Deno.open(path, { read: true });
   response.addResource(file.rid);

--- a/send_test.ts
+++ b/send_test.ts
@@ -391,7 +391,10 @@ test({
   async fn() {
     const { context } = setup("/test.json");
     const fixtureStat = await Deno.stat("./fixtures/test.json");
-    context.request.headers.set("If-Modified-Since", fixtureStat.mtime!.toUTCString());
+    context.request.headers.set(
+      "If-Modified-Since",
+      fixtureStat.mtime!.toUTCString(),
+    );
     await send(context, context.request.url.pathname, {
       root: "./fixtures",
     });

--- a/send_test.ts
+++ b/send_test.ts
@@ -385,3 +385,25 @@ test({
     context.response.destroy();
   },
 });
+
+test({
+  name: "send 304",
+  async fn() {
+    const { context } = setup("/test.json");
+    const fixtureStat = await Deno.stat("./fixtures/test.json");
+    context.request.headers.set("If-Modified-Since", fixtureStat.mtime!.toUTCString());
+    await send(context, context.request.url.pathname, {
+      root: "./fixtures",
+    });
+    const serverResponse = await context.response.toServerResponse();
+    assertStrictEquals(serverResponse.body, undefined);
+    assertEquals(serverResponse.status, 304);
+    assertEquals(context.response.type, ".json");
+    assertStrictEquals(context.response.headers.get("content-encoding"), null);
+    assertEquals(
+      context.response.headers.get("content-length"),
+      null,
+    );
+    context.response.destroy();
+  },
+});


### PR DESCRIPTION
It will check the `If-Modified-Since` request header, if the resource haven't been modified, then response with `304 Not Modified`.