### PR TITLE
Adds support for `ctx.locals` for temporary state (per-request).

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,15 +154,15 @@ The context passed to middleware has several properties:
 
 - `.state`
 
-  A record of global application state, which can be strongly typed by specifying 
-  a generic argument when constructing an `Application<MyState>()`, or inferred 
-  by passing a state object (e.g. `Application({ state })`).
-  
+  A record of global application state, which can be strongly typed by
+  specifying a generic argument when constructing an `Application<MyState>()`,
+  or inferred by passing a state object (e.g. `Application({ state })`).
+
 - `.locals`
 
-  A record of temporary request state that can be passed to front-end views. 
-  The type can be specified by passing the generic argument when constructing 
-  an `Application<MyState, MyLocals>()`.
+  A record of temporary request state that can be passed to front-end views. The
+  type can be specified by passing the generic argument when constructing an
+  `Application<MyState, MyLocals>()`.
 
 The context passed to middleware has some methods:
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,15 @@ The context passed to middleware has several properties:
 
 - `.state`
 
-  A record of application state, which can be strongly typed by specifying a
-  generic argument when constructing an `Application()`, or inferred by passing
-  a state object (e.g. `Application({ state })`).
+  A record of global application state, which can be strongly typed by specifying 
+  a generic argument when constructing an `Application<MyState>()`, or inferred 
+  by passing a state object (e.g. `Application({ state })`).
+  
+- `.locals`
+
+  A record of temporary request state that can be passed to front-end views. 
+  The type can be specified by passing the generic argument when constructing 
+  an `Application<MyState, MyLocals>()`.
 
 The context passed to middleware has some methods:
 

--- a/application.ts
+++ b/application.ts
@@ -141,9 +141,10 @@ export class ApplicationListenEvent extends Event {
  * The `context.state` can be typed via passing a generic argument when
  * constructing an instance of `Application`.
  */
-// deno-lint-ignore no-explicit-any
 export class Application<
+  // deno-lint-ignore no-explicit-any
   AS extends State = Record<string, any>,
+  // deno-lint-ignore no-explicit-any
   AL extends Locals = Record<string, any>,
 > extends EventTarget {
   #composedMiddleware?: (context: Context<AS>) => Promise<void>;

--- a/application.ts
+++ b/application.ts
@@ -144,7 +144,7 @@ export class ApplicationListenEvent extends Event {
 // deno-lint-ignore no-explicit-any
 export class Application<
   AS extends State = Record<string, any>,
-  AL extends Locals = Record<string, any>
+  AL extends Locals = Record<string, any>,
 > extends EventTarget {
   #composedMiddleware?: (context: Context<AS>) => Promise<void>;
   #keys?: KeyStack;

--- a/context.ts
+++ b/context.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the oak authors. All rights reserved. MIT license.
 
-import type { Application, State, Locals } from "./application.ts";
+import type { Application, Locals, State } from "./application.ts";
 import { Cookies } from "./cookies.ts";
 import { acceptable, acceptWebSocket, WebSocket } from "./deps.ts";
 import { createHttpError } from "./httpError.ts";
@@ -26,7 +26,7 @@ export interface ContextSendOptions extends SendOptions {
 // deno-lint-ignore no-explicit-any
 export class Context<
   S extends State = Record<string, any>,
-  L extends Locals = Record<string, any>
+  L extends Locals = Record<string, any>,
 > {
   #socket?: WebSocket;
   #sse?: ServerSentEventTarget;

--- a/context.ts
+++ b/context.ts
@@ -23,9 +23,10 @@ export interface ContextSendOptions extends SendOptions {
 
 /** Provides context about the current request and response to middleware
  * functions. */
-// deno-lint-ignore no-explicit-any
 export class Context<
+  // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  // deno-lint-ignore no-explicit-any
   L extends Locals = Record<string, any>,
 > {
   #socket?: WebSocket;

--- a/context_test.ts
+++ b/context_test.ts
@@ -12,7 +12,7 @@ import {
   BufWriter,
   test,
 } from "./test_deps.ts";
-import type { Application, State } from "./application.ts";
+import type { Application, Locals, State } from "./application.ts"
 import { Context } from "./context.ts";
 import { Cookies } from "./cookies.ts";
 import { Request } from "./request.ts";
@@ -20,9 +20,12 @@ import { Response } from "./response.ts";
 import { httpErrors } from "./httpError.ts";
 import type { ServerRequest } from "./types.d.ts";
 
-function createMockApp<S extends State = Record<string, any>>(
-  state = {} as S,
-): Application<S> {
+function createMockApp<
+  S extends State = Record<string, any>,
+  L extends Locals = Record<string, any>
+>(
+  state = {} as S
+): Application<S, L> {
   return {
     state,
     dispatchEvent() {},
@@ -70,6 +73,7 @@ test({
     const context = new Context(app, serverRequest);
     assert(context instanceof Context);
     assertStrictEquals(context.state, app.state);
+    assertEquals(context.locals, {});
     assertStrictEquals(context.app, app);
     assert(context.cookies instanceof Cookies);
     assert(context.request instanceof Request);

--- a/context_test.ts
+++ b/context_test.ts
@@ -12,7 +12,7 @@ import {
   BufWriter,
   test,
 } from "./test_deps.ts";
-import type { Application, Locals, State } from "./application.ts"
+import type { Application, Locals, State } from "./application.ts";
 import { Context } from "./context.ts";
 import { Cookies } from "./cookies.ts";
 import { Request } from "./request.ts";
@@ -22,9 +22,9 @@ import type { ServerRequest } from "./types.d.ts";
 
 function createMockApp<
   S extends State = Record<string, any>,
-  L extends Locals = Record<string, any>
+  L extends Locals = Record<string, any>,
 >(
-  state = {} as S
+  state = {} as S,
 ): Application<S, L> {
   return {
     state,


### PR DESCRIPTION
Fixes #283

Example:
```js
const app = new Application<any, { userId: number }>();
const router = new Router();
router.get("/", (context) => {
  context.locals.userId = authenticateRequest(context.request);
});
```