### PR TITLE
inform browsers that range requests are supported

### DIFF
--- a/send.ts
+++ b/send.ts
@@ -183,6 +183,11 @@ export async function send(
 
   response.headers.set("Content-Length", String(stats.size));
 
+  // Return the Accept-Ranges header so that browsers know they can request ranges. 
+  // This is useful for videos/resuming larger files etc. For more info see: 
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+  response.headers.set("Accept-Ranges", "bytes")
+
   const file = await Deno.open(path, { read: true });
   response.addResource(file.rid);
   response.body = file;

--- a/send.ts
+++ b/send.ts
@@ -183,10 +183,10 @@ export async function send(
 
   response.headers.set("Content-Length", String(stats.size));
 
-  // Return the Accept-Ranges header so that browsers know they can request ranges. 
-  // This is useful for videos/resuming larger files etc. For more info see: 
+  // Return the Accept-Ranges header so that browsers know they can request ranges.
+  // This is useful for videos/resuming larger files etc. For more info see:
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
-  response.headers.set("Accept-Ranges", "bytes")
+  response.headers.set("Accept-Ranges", "bytes");
 
   const file = await Deno.open(path, { read: true });
   response.addResource(file.rid);


### PR DESCRIPTION
Just opening this up to start off a discussion: I discovered that oak already supports range requests. So including this response header just gives browsers a heads up on this which comes in handy for <video> elements. Any interest in this PR? Happy to make this a sendOption or something similar, but I figure since it's supported it might as well default to being sent?
