### PR TITLE
fix: Parse bigint inside json response

### DIFF
--- a/response.ts
+++ b/response.ts
@@ -110,11 +110,7 @@ async function convertBody(
       json = JSON.stringify(body);
     } catch (e) {
       if (e.message.includes("BigInt")) {
-        json = JSON.stringify(
-          stringifyBigIntInObject(
-            body as JsonObject,
-          ),
-        );
+        json = JSON.stringify(stringifyBigIntInObject(body as JsonObject));
       } else {
         throw e;
       }

--- a/response_test.ts
+++ b/response_test.ts
@@ -93,9 +93,12 @@ test({
   name: "response.body as JSON",
   async fn() {
     const response = new Response(createMockRequest());
-    response.body = { foo: "bar" };
+    response.body = { foo: "bar", x: null, y: 17n, z: ["a", 2, 3n] };
     const serverResponse = await response.toServerResponse();
-    assertEquals(decodeBody(serverResponse.body), `{"foo":"bar"}`);
+    assertEquals(
+      decodeBody(serverResponse.body),
+      `{"foo":"bar","x":null,"y":"17","z":["a",2,"3"]}`,
+    );
     assertEquals(serverResponse.status, 200);
     assertEquals(
       serverResponse.headers.get("content-type"),


### PR DESCRIPTION
`JSON.stringify` doesn't natively transform bigint into string causing object responses containing bigints to throw. This aligns to the current oak behavior, in which if the response is a bigint it will be stringified as well.