### PR TITLE
feat: enable server-sent events for native HTTP bindings

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -384,7 +384,7 @@ export class Application<AS extends State = Record<string, any>>
       const [, hostname, portStr] = match;
       options = { hostname, port: parseInt(portStr, 10) };
     }
-    const server = new this.#serverConstructor(options);
+    const server = new this.#serverConstructor(this, options);
     const { signal } = options;
     const state = {
       closed: false,

--- a/application_test.ts
+++ b/application_test.ts
@@ -4,7 +4,12 @@
 
 import { assert, assertEquals, assertThrowsAsync, test } from "./test_deps.ts";
 
-import { Application, ListenOptions, ListenOptionsTls } from "./application.ts";
+import {
+  Application,
+  ListenOptions,
+  ListenOptionsTls,
+  State,
+} from "./application.ts";
 import { Context } from "./context.ts";
 import { Status } from "./deps.ts";
 import { NativeRequest } from "./http_server_native.ts";
@@ -27,8 +32,12 @@ function teardown() {
   serverClosed = false;
 }
 
-class MockServer implements Server<ServerRequest> {
-  constructor(options: Deno.ListenOptions | Deno.ListenTlsOptions) {
+class MockServer<AS extends State = Record<string, any>>
+  implements Server<ServerRequest> {
+  constructor(
+    _app: Application<AS>,
+    options: Deno.ListenOptions | Deno.ListenTlsOptions,
+  ) {
     optionsStack.push(options);
   }
 
@@ -43,8 +52,12 @@ class MockServer implements Server<ServerRequest> {
   }
 }
 
-class MockNativeServer implements Server<NativeRequest> {
-  constructor(options: Deno.ListenOptions | Deno.ListenTlsOptions) {
+class MockNativeServer<AS extends State = Record<string, any>>
+  implements Server<NativeRequest> {
+  constructor(
+    _app: Application<AS>,
+    options: Deno.ListenOptions | Deno.ListenTlsOptions,
+  ) {
     optionsStack.push(options);
   }
 

--- a/http_server_std.ts
+++ b/http_server_std.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the oak authors. All rights reserved. MIT license.
 
+import type { Application, State } from "./application.ts";
 import { serve, serveTLS } from "./deps.ts";
 import type { BufReader, BufWriter } from "./deps.ts";
 import type { Server } from "./types.d.ts";
@@ -31,10 +32,15 @@ export interface ServerResponse {
   body: Uint8Array | Deno.Reader | undefined;
 }
 
-export class HttpServerStd implements Server<ServerRequest> {
+// deno-lint-ignore no-explicit-any
+export class HttpServerStd<AS extends State = Record<string, any>>
+  implements Server<ServerRequest> {
   #server: StdServer;
 
-  constructor(options: Deno.ListenOptions | Deno.ListenTlsOptions) {
+  constructor(
+    _app: Application<AS>,
+    options: Deno.ListenOptions | Deno.ListenTlsOptions,
+  ) {
     this.#server = isListenTlsOptions(options)
       ? serveTLS(options)
       : serve(options);

--- a/mod.ts
+++ b/mod.ts
@@ -53,8 +53,10 @@ export type {
 export { send } from "./send.ts";
 export type { SendOptions } from "./send.ts";
 export { ServerSentEvent } from "./server_sent_event.ts";
-export type { ServerSentEventTarget } from "./server_sent_event.ts";
-export type { ServerSentEventInit } from "./server_sent_event.ts";
+export type {
+  ServerSentEventInit,
+  ServerSentEventTarget,
+} from "./server_sent_event.ts";
 export type { ErrorStatus, HTTPMethods, RedirectStatus } from "./types.d.ts";
 export { isErrorStatus, isRedirectStatus } from "./util.ts";
 

--- a/mod.ts
+++ b/mod.ts
@@ -52,7 +52,8 @@ export type {
 } from "./router.ts";
 export { send } from "./send.ts";
 export type { SendOptions } from "./send.ts";
-export { ServerSentEvent, ServerSentEventTarget } from "./server_sent_event.ts";
+export { ServerSentEvent } from "./server_sent_event.ts";
+export type { ServerSentEventTarget } from "./server_sent_event.ts";
 export type { ServerSentEventInit } from "./server_sent_event.ts";
 export type { ErrorStatus, HTTPMethods, RedirectStatus } from "./types.d.ts";
 export { isErrorStatus, isRedirectStatus } from "./util.ts";

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -28,10 +28,9 @@ test({
     assertEquals(typeof mod.Response, "function");
     assertEquals(typeof mod.Router, "function");
     assertEquals(typeof mod.ServerSentEvent, "function");
-    assertEquals(typeof mod.ServerSentEventTarget, "function");
     assertEquals(typeof mod.STATUS_TEXT, "object");
     assertEquals(typeof mod.Status, "object");
     assertEquals(typeof mod.send, "function");
-    assertEquals(Object.keys(mod).length, 21);
+    assertEquals(Object.keys(mod).length, 20);
   },
 });

--- a/server_sent_event.ts
+++ b/server_sent_event.ts
@@ -105,6 +105,9 @@ export interface ServerSentEventTarget extends EventTarget {
    * another event, comment or message is attempted to be processed. */
   readonly closed: boolean;
 
+  /** Close the target, refusing to accept any more events. */
+  close(): Promise<void>;
+
   /** Send a comment to the remote connection.  Comments are not exposed to the
    * client `EventSource` but are used for diagnostics and helping ensure a
    * connection is kept alive.
@@ -238,6 +241,11 @@ export class SSEStreamTarget extends EventTarget
         this.#controller.close();
       }
     });
+  }
+
+  close(): Promise<void> {
+    this.dispatchEvent(new CloseEvent({ cancelable: false }));
+    return Promise.resolve();
   }
 
   dispatchComment(comment: string): boolean {

--- a/server_sent_event.ts
+++ b/server_sent_event.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the oak authors. All rights reserved. MIT license.
 
 import type { Application } from "./application.ts";
+import type { Context } from "./context.ts";
 import { assert, BufWriter } from "./deps.ts";
 import { NativeRequest } from "./http_server_native.ts";
 import type { ServerRequest } from "./http_server_std.ts";
@@ -96,12 +97,178 @@ const responseHeaders = new Headers(
   ],
 );
 
-export class ServerSentEventTarget extends EventTarget {
+export interface ServerSentEventTarget extends EventTarget {
+  /** Is set to `true` if events cannot be sent to the remote connection.
+   * Otherwise it is set to `false`.
+   * 
+   * *Note*: This flag is lazily set, and might not reflect a closed state until
+   * another event, comment or message is attempted to be processed. */
+  readonly closed: boolean;
+
+  /** Send a comment to the remote connection.  Comments are not exposed to the
+   * client `EventSource` but are used for diagnostics and helping ensure a
+   * connection is kept alive.
+   * 
+   * ```ts
+   * import { Application } from "https://deno.land/x/oak/mod.ts";
+   * 
+   * const app = new Application();
+   * 
+   * app.use((ctx) => {
+   *    const sse = ctx.getSSETarget();
+   *    sse.dispatchComment("this is a comment");
+   * });
+   * 
+   * await app.listen();
+   * ```
+   */
+  dispatchComment(comment: string): boolean;
+
+  /** Dispatch a message to the client.  This message will contain `data: ` only
+   * and be available on the client `EventSource` on the `onmessage` or an event
+   * listener of type `"message"`. */
+  // deno-lint-ignore no-explicit-any
+  dispatchMessage(data: any): boolean;
+
+  /** Dispatch a server sent event to the client.  The event `type` will be
+   * sent as `event: ` to the client which will be raised as a `MessageEvent`
+   * on the `EventSource` in the client.
+   * 
+   * Any local event handlers will be dispatched to first, and if the event
+   * is cancelled, it will not be sent to the client.
+   * 
+   * ```ts
+   * import { Application, ServerSentEvent } from "https://deno.land/x/oak/mod.ts";
+   * 
+   * const app = new Application();
+   * 
+   * app.use((ctx) => {
+   *    const sse = ctx.getSSETarget();
+   *    const evt = new ServerSentEvent("ping", "hello");
+   *    sse.dispatchEvent(evt);
+   * });
+   * 
+   * await app.listen();
+   * ```
+   */
+  dispatchEvent(event: ServerSentEvent): boolean;
+
+  /** Dispatch a server sent event to the client.  The event `type` will be
+   * sent as `event: ` to the client which will be raised as a `MessageEvent`
+   * on the `EventSource` in the client.
+   * 
+   * Any local event handlers will be dispatched to first, and if the event
+   * is cancelled, it will not be sent to the client.
+   * 
+   * ```ts
+   * import { Application, ServerSentEvent } from "https://deno.land/x/oak/mod.ts";
+   * 
+   * const app = new Application();
+   * 
+   * app.use((ctx) => {
+   *    const sse = ctx.getSSETarget();
+   *    const evt = new ServerSentEvent("ping", "hello");
+   *    sse.dispatchEvent(evt);
+   * });
+   * 
+   * await app.listen();
+   * ```
+   */
+  dispatchEvent(event: CloseEvent | ErrorEvent): boolean;
+}
+
+export class SSEStreamTarget extends EventTarget
+  implements ServerSentEventTarget {
+  #closed = false;
+  #context: Context;
+  #controller?: ReadableStreamDefaultController<Uint8Array>;
+
+  // deno-lint-ignore no-explicit-any
+  #error = (error: any) => {
+    this.dispatchEvent(new CloseEvent({ cancelable: false }));
+    const errorEvent = new ErrorEvent("error", { error });
+    this.dispatchEvent(errorEvent);
+    this.#context.app.dispatchEvent(errorEvent);
+  };
+
+  #push = (payload: string) => {
+    if (!this.#controller) {
+      this.#error(new Error("The controller has not been set."));
+      return;
+    }
+    if (this.#closed) {
+      return;
+    }
+    this.#controller.enqueue(encoder.encode(payload));
+  };
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  constructor(
+    context: Context,
+    { headers }: ServerSentEventTargetOptions = {},
+  ) {
+    super();
+
+    this.#context = context;
+
+    context.response.body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        this.#controller = controller;
+      },
+      cancel: (error) => {
+        this.#error(error);
+      },
+    });
+
+    if (headers) {
+      for (const [key, value] of headers) {
+        context.response.headers.set(key, value);
+      }
+    }
+    for (const [key, value] of responseHeaders) {
+      context.response.headers.set(key, value);
+    }
+
+    this.addEventListener("close", () => {
+      this.#closed = true;
+      if (this.#controller) {
+        this.#controller.close();
+      }
+    });
+  }
+
+  dispatchComment(comment: string): boolean {
+    this.#push(`: ${comment.split("\n").join("\n: ")}\n\n`);
+    return true;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  dispatchMessage(data: any): boolean {
+    const event = new ServerSentEvent("__message", data);
+    return this.dispatchEvent(event);
+  }
+
+  dispatchEvent(event: ServerSentEvent): boolean;
+  dispatchEvent(event: CloseEvent | ErrorEvent): boolean;
+  dispatchEvent(event: ServerSentEvent | CloseEvent | ErrorEvent): boolean {
+    const dispatched = super.dispatchEvent(event);
+    if (dispatched && event instanceof ServerSentEvent) {
+      this.#push(String(event));
+    }
+    return dispatched;
+  }
+}
+
+export class SSEStdLibTarget extends EventTarget
+  implements ServerSentEventTarget {
   #app: Application;
   #closed = false;
   #prev = Promise.resolve();
   #ready: Promise<void> | true;
-  #serverRequest: ServerRequest | NativeRequest;
+  #serverRequest: ServerRequest;
   #writer: BufWriter;
 
   #send = async (payload: string, prev: Promise<void>): Promise<void> => {
@@ -148,26 +315,18 @@ export class ServerSentEventTarget extends EventTarget {
     }
   };
 
-  /** Is set to `true` if events cannot be sent to the remote connection.
-   * Otherwise it is set to `false`.
-   * 
-   * *Note*: This flag is lazily set, and might not reflect a closed state until
-   * another event, comment or message is attempted to be processed. */
   get closed(): boolean {
     return this.#closed;
   }
 
   constructor(
-    app: Application,
-    serverRequest: ServerRequest | NativeRequest,
+    context: Context,
     { headers }: ServerSentEventTargetOptions = {},
   ) {
     super();
-    if (serverRequest instanceof NativeRequest) {
-      throw new TypeError("SSE with native Deno requests not yet supported.");
-    }
-    this.#app = app;
-    this.#serverRequest = serverRequest;
+    this.#app = context.app;
+    assert(!(context.request.originalRequest instanceof NativeRequest));
+    this.#serverRequest = context.request.originalRequest;
     this.#writer = this.#serverRequest.w;
     this.addEventListener("close", () => {
       this.#closed = true;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2021 the oak authors. All rights reserved. MIT license.
 
-import { Status } from "./deps.ts";
+import type { Application, State } from "./application.ts";
+import type { Status } from "./deps.ts";
 
 /** A HTTP status that is an error (4XX and 5XX). */
 export type ErrorStatus =
@@ -69,6 +70,10 @@ export interface Server<T> extends AsyncIterable<T> {
 }
 
 export interface ServerConstructor<T> {
-  new (options: Deno.ListenOptions | Deno.ListenTlsOptions): Server<T>;
+  // deno-lint-ignore no-explicit-any
+  new <AS extends State = Record<string, any>>(
+    app: Application<AS>,
+    options: Deno.ListenOptions | Deno.ListenTlsOptions,
+  ): Server<T>;
   prototype: Server<T>;
 }


### PR DESCRIPTION
The enables server-sent events for the native HTTP bindings.

It requires denoland/deno#10197, which will be in Deno 1.9.1 (or canary release). (In Deno 1.9.0 it will cause a server to exit with an unhandled error when a client navigates away from the page)