### PR TITLE
Remove extra CRLF in multipart

### DIFF
--- a/multipart.ts
+++ b/multipart.ts
@@ -185,7 +185,10 @@ async function* parts(
             // remove extra 2 bytes ([CR, LF]) from result file
             const bytesDiff = bytes.length - strippedBytes.length;
             if (bytesDiff) {
-              const originalBytesSize = await file.seek(-bytesDiff, Deno.SeekMode.Current);
+              const originalBytesSize = await file.seek(
+                -bytesDiff,
+                Deno.SeekMode.Current,
+              );
               await file.truncate(originalBytesSize);
             }
 

--- a/multipart.ts
+++ b/multipart.ts
@@ -182,6 +182,13 @@ async function* parts(
         const strippedBytes = stripEol(bytes);
         if (isEqual(strippedBytes, part) || isEqual(strippedBytes, final)) {
           if (file) {
+            // remove extra 2 bytes ([CR, LF]) from result file
+            const bytesDiff = bytes.length - strippedBytes.length;
+            if (bytesDiff) {
+              const originalBytesSize = await file.seek(-bytesDiff, Deno.SeekMode.Current);
+              await file.truncate(originalBytesSize);
+            }
+
             file.close();
           }
           yield [

--- a/multipart_test.ts
+++ b/multipart_test.ts
@@ -241,7 +241,8 @@ test({
 });
 
 test({
-  name: "multipart - FormDataReader - .read() no extra CRLF at the end of result file if origin file doesn't end with newline",
+  name:
+    "multipart - FormDataReader - .read() no extra CRLF at the end of result file if origin file doesn't end with newline",
   async fn() {
     const body = createBody(fixtureNoNewline);
     const fdr = new FormDataReader(fixtureContentType, body);

--- a/multipart_test.ts
+++ b/multipart_test.ts
@@ -60,6 +60,15 @@ export { printHello } from "./print_hello.ts";
 --OAK-SERVER-BOUNDARY--
 `;
 
+const fixtureNoNewline = `
+--OAK-SERVER-BOUNDARY
+Content-Disposition: form-data; name="noNewline"; filename="noNewline.txt"
+Content-Type: text/plain
+
+555
+--OAK-SERVER-BOUNDARY--
+`;
+
 function createBody(value: string): Buffer {
   return new Buffer(encoder.encode(value));
 }
@@ -228,5 +237,24 @@ test({
     assertEquals(actual.files[0].contentType, "video/mp2t");
     assertEquals(actual.files[0].name, "filea");
     assertEquals(actual.files[0].originalName, "编写软件很难.ts");
+  },
+});
+
+test({
+  name: "multipart - FormDataReader - .read() no extra CRLF at the end of result file if origin file doesn't end with newline",
+  async fn() {
+    const body = createBody(fixtureNoNewline);
+    const fdr = new FormDataReader(fixtureContentType, body);
+    const actual = await fdr.read();
+
+    assert(actual.files);
+    assertEquals(actual.files.length, 1);
+    assertEquals(actual.files[0].contentType, "text/plain");
+    assertEquals(actual.files[0].name, "noNewline");
+    assertEquals(actual.files[0].originalName, "noNewline.txt");
+    assert(actual.files[0].filename);
+
+    const file = await Deno.stat(actual.files[0].filename);
+    assertEquals(file.size, 3);
   },
 });


### PR DESCRIPTION
Resolves #335 

Fixes bug in mutipart with extra CRLF at the end of result files which in origin doesn't have newline at the end.