### PR TITLE
Fix: Retain search params of query url during proxying

### DIFF
--- a/middleware/proxy.ts
+++ b/middleware/proxy.ts
@@ -124,6 +124,8 @@ async function createRequest<P extends RouteParams, S extends State>(
   } else {
     url.pathname = `${url.pathname}${path}`;
   }
+  url.search = ctx.request.url.search;
+
   const body = getBodyInit(ctx);
   const headers = new Headers(ctx.request.headers);
   if (optHeaders) {

--- a/middleware/proxy_test.ts
+++ b/middleware/proxy_test.ts
@@ -178,3 +178,22 @@ Deno.test({
     assertStrictEquals(ctx.response.headers.get("content-type"), "text/html");
   },
 });
+
+Deno.test({
+  name: "proxy - preserves - search params",
+  async fn() {
+    function fetch(request: Request) {
+      const url = new URL(request.url);
+      assertStrictEquals(url.search, ctx.request.url.search);
+      return Promise.resolve(new Response("hello world"));
+    }
+
+    const mw = proxy("https://oakserver.github.io/", { fetch });
+
+    const next = createMockNext();
+    const ctx = createMockContext({
+      path: "/oak/index.html?query=foobar&page=42",
+    });
+    await mw(ctx, next);
+  },
+});


### PR DESCRIPTION
Fixes #346
