### PR TITLE
[chore] Small clean-up of logic in `HttpError` constructor

### DIFF
--- a/httpError.ts
+++ b/httpError.ts
@@ -92,7 +92,7 @@ function createHttpErrorConstructor<E extends typeof HttpError>(
     constructor(message?: string) {
       super(message || STATUS_TEXT.get(status));
       this.status = status;
-      this.expose = status >= 400 && status < 500 ? true : false;
+      this.expose = status >= 400 && status < 500;
       Object.defineProperty(this, "name", {
         configurable: true,
         enumerable: false,

--- a/httpError.ts
+++ b/httpError.ts
@@ -90,9 +90,7 @@ function createHttpErrorConstructor<E extends typeof HttpError>(
   const name = `${Status[status]}Error`;
   const Ctor = class extends HttpError {
     constructor(message?: string) {
-      super();
-      // deno-lint-ignore no-explicit-any
-      this.message = message || STATUS_TEXT.get(status as any)!;
+      super(message || STATUS_TEXT.get(status));
       this.status = status;
       this.expose = status >= 400 && status < 500 ? true : false;
       Object.defineProperty(this, "name", {


### PR DESCRIPTION
This PR fixes some minor issues I found while perusing the `httpError.ts` file.

The first commit delegates the assignment of the `HttpError#message` property to the `super` constructor of `Error`. This is so that the `message` is passed up to the prototype of `Error` rather than creating a whole new instance of `message` in `this` (`HttpError`).

Finally, the second commit simply removes a redundant usage of the ternary operator.

If there are any issues with these changes, please do inform me. I shall gladly resolve them and adjust the PR accordingly. Thanks!