### PR TITLE
Allow streaming the request body multiple times

### DIFF
--- a/body.ts
+++ b/body.ts
@@ -147,6 +147,7 @@ function bodyAsStream(
 
 export class RequestBody {
   #formDataReader?: FormDataReader;
+  #stream?: ReadableStream<Uint8Array>;
   #has?: boolean;
   #readAllBody?: Promise<Uint8Array>;
   #request: Request | ServerRequest;
@@ -254,7 +255,9 @@ export class RequestBody {
         );
       }
       this.#type = "stream";
-      return { type, value: bodyAsStream(this.#request.body) };
+      const streams = (this.#stream ?? bodyAsStream(this.#request.body)).tee();
+      this.#stream = streams[1];
+      return { type, value: streams[0] };
     }
     if (!this.has()) {
       this.#type = "undefined";

--- a/body_test.ts
+++ b/body_test.ts
@@ -204,6 +204,22 @@ test({
 });
 
 test({
+  name: "body - type: stream",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest({
+      body: "hello world",
+      headerValues: {
+        "content-type": "text/plain",
+      },
+    }));
+    const body = requestBody.get({ type: "stream" });
+    assert(body.type === "stream");
+    const actual = await new Response(body.value).text();
+    assertEquals(actual, "hello world");
+  },
+});
+
+test({
   name: "body - type: form",
   async fn() {
     const requestBody = new RequestBody(createMockServerRequest(
@@ -464,5 +480,24 @@ test({
     const actual = requestBody.get({});
     assertEquals(actual.type, "text");
     assertEquals(await actual.value, "hello deno");
+  },
+});
+
+test({
+  name: "body - multiple streams",
+  async fn() {
+    const requestBody = new RequestBody(createMockServerRequest({
+      body: "hello world",
+      headerValues: {
+        "content-type": "text/plain",
+      },
+    }));
+    const a = requestBody.get({ type: "stream" });
+    const b = requestBody.get({ type: "stream" });
+    assert(a.type === "stream");
+    assert(b.type === "stream");
+    const textA = await new Response(a.value).text();
+    const textB = await new Response(b.value).text();
+    assertEquals(textA, textB);
   },
 });


### PR DESCRIPTION
In order to inspect a request's body before giving it to the proxy middleware, we need to consume it.
`proxy` uses `request.body({ type: "stream" })`, so we have to use the same method. All other methods are incompatible.
Still this means we read from the same underlying stream or Deno.Reader, which will fail.

This change returns a new independent reader, so the body can be read multiple times from various middleware that are unaware of each other.