### PR TITLE
fix: ensure can close the native server by closing open http connections

### DIFF
--- a/.github/workflows/oak-ci.yml
+++ b/.github/workflows/oak-ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: deno lint --unstable
 
       - name: run tests
-        run: deno test --allow-read --allow-write
+        run: deno test --allow-read --allow-write --allow-net
 
       - name: run tests unstable
         run: deno test --coverage=./cov --allow-read --allow-write --allow-net --unstable

--- a/http_server_native_test.ts
+++ b/http_server_native_test.ts
@@ -2,7 +2,11 @@
 
 import { assertEquals, assertStrictEquals, unreachable } from "./test_deps.ts";
 
-import { hasNativeHttp, NativeRequest, HttpServerNative } from "./http_server_native.ts";
+import {
+  hasNativeHttp,
+  HttpServerNative,
+  NativeRequest,
+} from "./http_server_native.ts";
 
 import { Application } from "./application.ts";
 
@@ -51,14 +55,14 @@ test({
   name: "HttpServerNative closes gracefully after serving requests",
   async fn() {
     const app = new Application();
-    const listenOptions = { port: 4505 }
+    const listenOptions = { port: 4505 };
 
     const server = new HttpServerNative(app, listenOptions);
     server.listen();
 
     const expectedBody = "test-body";
 
-    (async() => {
+    (async () => {
       for await (const nativeRequest of server) {
         nativeRequest.respond(new Response(expectedBody));
       }
@@ -72,5 +76,5 @@ test({
     } finally {
       server.close();
     }
-  }
-})
+  },
+});

--- a/http_server_native_test.ts
+++ b/http_server_native_test.ts
@@ -1,8 +1,10 @@
 // Copyright 2018-2021 the oak authors. All rights reserved. MIT license.
 
-import { assertEquals, assertStrictEquals } from "./test_deps.ts";
+import { assertEquals, assertStrictEquals, unreachable } from "./test_deps.ts";
 
-import { hasNativeHttp, NativeRequest } from "./http_server_native.ts";
+import { hasNativeHttp, NativeRequest, HttpServerNative } from "./http_server_native.ts";
+
+import { Application } from "./application.ts";
 
 const { test } = Deno;
 
@@ -44,3 +46,31 @@ test({
     assertStrictEquals(await respondWithStack[0], response);
   },
 });
+
+test({
+  name: "HttpServerNative closes gracefully after serving requests",
+  async fn() {
+    const app = new Application();
+    const listenOptions = { port: 4505 }
+
+    const server = new HttpServerNative(app, listenOptions);
+    server.listen();
+
+    const expectedBody = "test-body";
+
+    (async() => {
+      for await (const nativeRequest of server) {
+        nativeRequest.respond(new Response(expectedBody));
+      }
+    })();
+
+    try {
+      const response = await fetch(`http://localhost:${listenOptions.port}`);
+      assertEquals(await response.text(), expectedBody);
+    } catch {
+      unreachable();
+    } finally {
+      server.close();
+    }
+  }
+})

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -19,5 +19,6 @@ export {
   assertStrictEquals,
   assertThrows,
   assertThrowsAsync,
+  unreachable,
 } from "https://deno.land/std@0.105.0/testing/asserts.ts";
 export type { WebSocketEvent } from "https://deno.land/std@0.105.0/ws/mod.ts";


### PR DESCRIPTION
Fixes #314 

Recent comment prompted me to revisit this.

Having gone through the process of writing https://github.com/denoland/deno_std/pull/1128, now confident the root cause of the issue is that http connections are not closed when the underlying listener is closed - we need to track these connections and ensure that we close them off in order for the `httpConn.nextRequest()` to resolve (as `null`) otherwise it hangs forever.

This addition tracks each new `httpConn` to a set and then removes it again once / if the `httpConn` is closed again. We then update the server `close()` method to loop over the outstanding `httpConn`s in the set and close them.

Added test case that now passes following fixes.