### PR TITLE
docs(testing.md): fix type MiddleWare not found to MiddleWare url

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,8 +24,7 @@ In the following example, we will create a middleware that checks if the request
 path is `"/a"` and if so, sets the body and a header in the response:
 
 ```ts
-import { testing } from "https://deno.land/x/oak/mod.ts";
-import type { Middleware } from "https://deno.land/x/mod.ts";
+import { testing, Middleware } from "https://deno.land/x/oak/mod.ts";
 import { assert, assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
 const mw: Middleware = async (ctx, next) => {


### PR DESCRIPTION
## The existing import statement causes Not Found.
change 
```import type { Middleware } from "https://deno.land/x/mod.ts";```   to 
 ```import { testing, Middleware } from "https://deno.land/x/oak/mod.ts";```