### PR TITLE
Fix upgrading connection to WebSocket

### DIFF
--- a/.github/workflows/oak-ci.yml
+++ b/.github/workflows/oak-ci.yml
@@ -37,12 +37,12 @@ jobs:
       - name: run tests using dom libs
         run: deno test --unstable --allow-read --allow-write --allow-net --config dom.tsconfig.json --jobs 4
 
-      - name: generate lcov
-        if: matrix.os == 'ubuntu-latest'
-        run: deno coverage --unstable --lcov ./cov > cov.lcov
+      # - name: generate lcov
+      #   if: matrix.os == 'ubuntu-latest'
+      #   run: deno coverage --unstable --lcov ./cov > cov.lcov
 
-      - name: upload coverage
-        if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v1
-        with:
-          files: cov.lcov
+      # - name: upload coverage
+      #   if: matrix.os == 'ubuntu-latest'
+      #   uses: codecov/codecov-action@v1
+      #   with:
+      #     files: cov.lcov

--- a/application.ts
+++ b/application.ts
@@ -133,7 +133,6 @@ export interface ApplicationOptions<S> {
    *   // evt.error will contain what error was thrown
    * });
    * ```
-   *
    */
   logErrors?: boolean;
 

--- a/body.ts
+++ b/body.ts
@@ -65,10 +65,10 @@ export interface BodyOptionsContentTypes {
   /** Content types listed here will be parsed as a JSON string. */
   json?: string[];
   /** Content types listed here will be parsed as form data and return
-     * `URLSearchParameters` as the value of the body. */
+   * `URLSearchParameters` as the value of the body. */
   form?: string[];
   /** Content types listed here will be parsed as from data and return a
-     * `FormDataBody` interface as the value of the body. */
+   * `FormDataBody` interface as the value of the body. */
   formData?: string[];
   /** Content types listed here will be parsed as text. */
   text?: string[];

--- a/context_test.ts
+++ b/context_test.ts
@@ -101,7 +101,7 @@ function createMockNativeRequest(
     ? undefined
     : (request, options) => {
       upgradeWebSocketStack.push([request, options]);
-      return { response: mockResponse, websocket: mockWebSocket };
+      return { response: mockResponse, socket: mockWebSocket };
     };
   return new NativeRequest(requestEvent, { upgradeWebSocket });
 }

--- a/deploy_test.ts
+++ b/deploy_test.ts
@@ -10,7 +10,9 @@ Deno.test({
   name: "deploy - fetch event API",
   ignore: notUnstable,
   async fn() {
-    const worker = await createWorker("./fixtures/deploy_diagnostics.ts");
+    const worker = await createWorker("./fixtures/deploy_diagnostics.ts", {
+      bundle: false,
+    });
     await worker.run(async () => {
       const [response] = await worker.fetch("/");
       assertEquals(await response.json(), {
@@ -28,7 +30,9 @@ Deno.test({
   name: "deploy - request event API",
   ignore: notUnstable,
   async fn() {
-    const worker = await createWorker("./fixtures/deploy_request_event.ts");
+    const worker = await createWorker("./fixtures/deploy_request_event.ts", {
+      bundle: false,
+    });
     await worker.run(async () => {
       const logs: string[] = [];
       (async () => {

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -39,7 +39,7 @@ const serveHttp: (conn: Deno.Conn) => HttpConn = "serveHttp" in Deno
 
 interface WebSocketUpgrade {
   response: Response;
-  websocket: WebSocket;
+  socket: WebSocket;
 }
 
 export type UpgradeWebSocketFn = (
@@ -157,13 +157,13 @@ export class NativeRequest {
     if (!this.#upgradeWebSocket) {
       throw new TypeError("Upgrading web sockets not supported.");
     }
-    const { response, websocket } = this.#upgradeWebSocket(
+    const { response, socket } = this.#upgradeWebSocket(
       this.#request,
       options,
     );
     this.#resolve(response);
     this.#resolved = true;
-    return websocket;
+    return socket;
   }
 }
 

--- a/middleware/proxy.ts
+++ b/middleware/proxy.ts
@@ -63,7 +63,7 @@ export interface ProxyOptions<
    * If the value is a string the match will be true if the requests pathname
    * starts with the string. In the case of a regular expression, if the
    * pathname
-   * */
+   */
   match?:
     | string
     | RegExp

--- a/send.ts
+++ b/send.ts
@@ -51,7 +51,6 @@ export interface SendOptions {
    *   })
    * });
    * ```
-   *
    */
   contentTypes?: Record<string, string>;
 

--- a/util.ts
+++ b/util.ts
@@ -134,7 +134,6 @@ export interface ReadableStreamFromReaderOptions {
  * const file = await Deno.open("./file.txt", { read: true });
  * const fileStream = readableStreamFromReader(file);
  * ```
- *
  */
 export function readableStreamFromReader(
   reader: Deno.Reader | (Deno.Reader & Deno.Closer),


### PR DESCRIPTION
Previously, upgrading a connection would fail because of an incorrectly named attribute. Now it won't.

fix #370