### PR TITLE
fix: mocked contexts provide the cookies property

### DIFF
--- a/testing_test.ts
+++ b/testing_test.ts
@@ -52,6 +52,40 @@ Deno.test({
 });
 
 Deno.test({
+  name: "testing - ctx.cookies.set()",
+  async fn() {
+    const ctx = createMockContext();
+    await ctx.cookies.set(
+      "sessionID",
+      "S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro",
+      { httpOnly: true },
+    );
+    assertEquals([...ctx.response.headers], [
+      [
+        "set-cookie",
+        "sessionID=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro; path=/; httponly",
+      ],
+    ]);
+  },
+});
+
+Deno.test({
+  name: "testing - ctx.cookies.get()",
+  async fn() {
+    const ctx = createMockContext({
+      headers: [[
+        "cookie",
+        "sessionID=S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro;",
+      ]],
+    });
+    assertEquals(
+      await ctx.cookies.get("sessionID"),
+      "S7GhXzJF3n4j8JwTupr7H-h25qtt_vs0stdETXZb-Ro",
+    );
+  },
+});
+
+Deno.test({
   name: "testing - createMockNext()",
   fn() {
     const next = createMockNext();


### PR DESCRIPTION
fix: https://github.com/oakserver/oak/issues/379

I found it inconvenient that the cookies property is not available in MockContext, so I made it possible to provide the cookies property. 
I've also added test cases for ctx.cookies.get() and ctx.cookies.set().