### PR TITLE
fix: getQuery() may have undefined values

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -25,18 +25,18 @@ export type GetParamsOptions = GetQueryOptionsBase | GetQueryOptionsAsMap;
 export function getQuery(
   ctx: Context | RouterContext,
   options: GetQueryOptionsAsMap,
-): Map<string, string>;
+): Map<string, string | undefined>;
 /** Given a context, return the `.request.url.searchParams` as a record object
  * of keys and values of the params. */
 export function getQuery(
   ctx: Context | RouterContext,
   options?: GetQueryOptionsBase,
-): Record<string, string>;
+): Record<string, string | undefined>;
 export function getQuery(
   ctx: Context | RouterContext,
   { mergeParams, asMap }: GetParamsOptions = {},
-): Map<string, string> | Record<string, string> {
-  const result: Record<string, string> = {};
+): Map<string, string | undefined> | Record<string, string | undefined> {
+  const result: Record<string, string | undefined> = {};
   if (mergeParams && isRouterContext(ctx)) {
     Object.assign(result, ctx.params);
   }


### PR DESCRIPTION
Hello, I am using Deno to try to write a chatroom demo, and now I think I've encountered a problem. Here's an example code:

```ts
const username = helpers.getQuery(context).username;
```

Here the VSCode just infers that the type of username is just string and wouldn't be undefined because the type of the return value of `getQuery()` is `Record<string, string>`. But in fact it sometimes does occur. And it also made me ignore considering the situation that the username would be empty so I didn't write the relevant code to check and avoid it. It may make debug hard so I just modified the type of the return value.