### PR TITLE
Fix(testing): implement mock for `Request#accepts`

### DIFF
--- a/testing.ts
+++ b/testing.ts
@@ -60,19 +60,15 @@ export function createMockContext<
   S extends State = Record<string, any>,
 >(
   {
-    app,
     ip = "127.0.0.1",
     method = "GET",
     params,
     path = "/",
     state,
+    app = createMockApp(state),
     headers,
   }: MockContextOptions<R> = {},
 ) {
-  if (!app) {
-    app = createMockApp(state);
-  }
-
   function createMockRequest(): Request {
     return {
       acceptsEncodings() {

--- a/testing.ts
+++ b/testing.ts
@@ -25,7 +25,7 @@ export function createMockApp<
       return app;
     },
     [Symbol.for("Deno.customInspect")]() {
-      return `MockApplication {}`;
+      return "MockApplication {}";
     },
   } as any;
   return app;

--- a/testing.ts
+++ b/testing.ts
@@ -12,6 +12,7 @@ import type { ErrorStatus } from "./types.d.ts";
 import { Cookies } from "./cookies.ts";
 import { Request } from "./request.ts";
 import { Response } from "./response.ts";
+import { preferredMediaTypes } from "./negotiation/mediaType.ts";
 
 /** Creates a mock of `Application`. */
 export function createMockApp<
@@ -70,11 +71,22 @@ export function createMockContext<
   }: MockContextOptions<R> = {},
 ) {
   function createMockRequest(): Request {
+    const headerMap = new Headers(headers);
     return {
+      accepts(...types: string[]) {
+        const acceptValue = headerMap.get("Accept");
+        if (!acceptValue) {
+          return;
+        }
+        if (types.length) {
+          return preferredMediaTypes(acceptValue, types)[0];
+        }
+        return preferredMediaTypes(acceptValue);
+      },
       acceptsEncodings() {
         return mockContextState.encodingsAccepted;
       },
-      headers: new Headers(headers),
+      headers: headerMap,
       ip,
       method,
       path,

--- a/testing_test.ts
+++ b/testing_test.ts
@@ -35,6 +35,8 @@ Deno.test({
     assertEquals(ctx.request.url.pathname, "/");
     assertEquals(ctx.state, {});
     assertEquals(ctx.request.acceptsEncodings("identity"), "identity");
+    ctx.response.redirect("/hello/world");
+    assertEquals(ctx.response.headers.get("Location"), "/hello/world");
   },
 });
 


### PR DESCRIPTION
Previously, the following mocked test will fail to compile.

```typescript
import { testing } from 'oak';
import { assertEquals } from 'std/testing/assert.ts';

Deno.test({
    name: 'should redirect user',
    fn() {
      const ctx = testing.createMockContext();
      ctx.response.redirect('/hello/world');
      assertEquals(ctx.response.headers.get('Location'), '/hello/world');
    },
});
```

A seemingly irrelevant error message will report that the failure is due to the fact that "`this.#request.accepts` is `undefined`". This is because the `Response#redirect` implementation internally invokes the `Request#accepts` method (as seen below).

https://github.com/oakserver/oak/blob/b85ffc3d48af6b0d6c3b3a37aa5142dbc068cffd/response.ts#L255-L260

However, prior to this PR, the mocked `Request` did not implement the `accepts` method, hence the compilation error.

https://github.com/oakserver/oak/blob/b85ffc3d48af6b0d6c3b3a37aa5142dbc068cffd/testing.ts#L76-L89

Anyway, if there are any issues with this PR, I will gladly resolve them. Thanks! 🎉