### PR TITLE
fix: use interface to represent `Deno.core` instead of modifying global type scope

### DIFF
--- a/structured_clone.ts
+++ b/structured_clone.ts
@@ -29,14 +29,10 @@ export type StructuredClonable =
   | TypeError
   | URIError;
 
-declare global {
-  namespace Deno {
-    // deno-lint-ignore no-var
-    var core: {
-      deserialize(value: unknown): StructuredClonable;
-      serialize(value: StructuredClonable): unknown;
-    };
-  }
+/** Internal functions on the `Deno.core` namespace */
+interface DenoCore {
+  deserialize(value: unknown): StructuredClonable;
+  serialize(value: StructuredClonable): unknown;
 }
 
 const objectCloneMemo = new WeakMap();
@@ -145,7 +141,8 @@ function cloneValue(value: any): any {
   }
 }
 
-const core = Deno?.core;
+// deno-lint-ignore no-explicit-any
+const core = (Deno as any)?.core as DenoCore | undefined;
 const structuredClone: ((value: unknown) => unknown) | undefined =
   // deno-lint-ignore no-explicit-any
   (globalThis as any).structuredClone;


### PR DESCRIPTION
This will fix this dnt issue:

```ts
npm/src/structured_clone.ts:149:28 - error TS2339: Property 'core' does not exist on type 'typeof Deno'.

149 const core = dntShim.Deno?.core;
                               ~~~~
```

Getting dnt to understand global scope augmentation will be a challenge... I'm not sure how it will do it with shimming, but hopefully the occurrences of this will be rare so people can work around it.