### PR TITLE
README: Added `await` to etag.calculate

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ import { etag } from "https://deno.land/x/oak/mod.ts";
 
 export async function mw(context, next) {
   await next();
-  const value = etag.calculate("hello deno");
+  const value = await etag.calculate("hello deno");
   context.response.headers.set("ETag", value);
 }
 ```


### PR DESCRIPTION
This method is (now) async as it turns out.