### PR TITLE
Add missing await in Readme.md Static Content example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ app.use(async (context, next) => {
       index: "index.html",
     });
   } catch {
-    next();
+    await next();
   }
 });
 


### PR DESCRIPTION
There's an `await` missing in the Static Content exmple of the Readme. This was causing the dreaded "The response is not writable." error in my case.