### PR TITLE
Add helper to handle .stream() case of form body

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -51,3 +51,64 @@ export function getQuery(
   }
   return asMap ? new Map(Object.entries(result)) : result;
 }
+
+
+export function createObjectForField(
+  obj: Record<string, unknown>,
+  string: string,
+  value: unknown,
+): Record<string, unknown> {
+  // "reminder[fulfilled][id][]"
+  const [root, ...nestedKeys] = string.split("[").filter((i) => i !== "]").map(
+    (i) => i.split("]")[0],
+  );
+  // root -> reminder, nestedKeys -> [fulfilled, id]
+
+  // quick return in case object has no nested keys
+  if (nestedKeys.length === 0) {
+    obj[root] = value;
+    return obj;
+  }
+
+  // check to see that object has the property
+  if (!Object.prototype.hasOwnProperty.call(obj, root)) obj[root] = {};
+
+  // identification of array cases for handling down the chain
+  let isArrayCase = false;
+  if (string.endsWith("[]")) {
+    isArrayCase = true;
+  }
+
+  // Additionally also check if the array already exists in which case direct push should be allowed
+
+  // [reminder, fulfilled, id]
+
+  nestedKeys.reduce((prev: Record<string, unknown>, currentKey) => {
+    if (currentKey === nestedKeys[nestedKeys.length - 1]) {
+      if (isArrayCase) {
+        if (
+          Object.prototype.hasOwnProperty.call(prev, currentKey)
+        ) {
+          {
+            const curVal = prev[currentKey];
+            if (Array.isArray(curVal)) {
+              curVal.push(value);
+            }
+          }
+        } else {
+          prev[currentKey] = [value];
+        }
+      } else {
+        prev[currentKey] = value;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(prev, currentKey)) {
+      return prev[currentKey] as Record<string, unknown>;
+    } else {
+      prev[currentKey] = {};
+      return prev[currentKey] as Record<string, unknown>;
+    }
+  }, obj[root] as Record<string, unknown>);
+  return obj;
+}

--- a/helpers_test.ts
+++ b/helpers_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the oak authors. All rights reserved. MIT license.
 
-import { getQuery } from "./helpers.ts";
+import { getQuery, createObjectForField } from "./helpers.ts";
 import { assertEquals } from "./test_deps.ts";
 import { createMockContext } from "./testing.ts";
 
@@ -36,4 +36,80 @@ test({
       { foo: "bar", baz: "qat", bar: "baz" },
     );
   },
+});
+
+test({
+  name: "creating object from string keys corresponding to the AsyncIterableIterator keys and values received from .stream() method on form-data body",
+  fn: async (t) => {
+    await t.step({
+      name: "basic case",
+      fn: () => {
+        const startObj = {};
+        let key = "data";
+        let value: unknown = 12;
+        assertEquals(
+          JSON.stringify(createObjectForField(startObj, key, value)),
+          '{"data":12}',
+        );
+        key = "ok";
+        value = true;
+        assertEquals(
+          JSON.stringify(createObjectForField(startObj, key, value)),
+          '{"data":12,"ok":true}'
+        )
+      }
+    });
+    await t.step({
+      name: "simple nesting",
+      fn: () => {
+        let key = "reminder[testing]";
+        const tempObj = {};
+        let value = 51;
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj,key, value)),
+          '{"reminder":{"testing":51}}',
+        );
+        
+        key = "testingFirst";
+        value = 15;
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj, key, value)),
+          '{"reminder":{"testing":51},"testingFirst":15}',
+        );
+      }
+    });
+    await t.step({
+      name: "nested fields with array",
+      fn: () => {
+        let key = "reminder[fulfilled][id][]";
+        let value = 55;
+        const tempObj = {};
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj, key, value)),
+          '{"reminder":{"fulfilled":{"id":[55]}}}',
+        );
+
+         key= "top[middle][bottom][]";
+        value = 101;
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj, key, value)),
+          '{"reminder":{"fulfilled":{"id":[55]}},"top":{"middle":{"bottom":[101]}}}',
+        );
+
+        // attempting to add additional values to an existing key
+        value = 102
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj, key, value)),
+          '{"reminder":{"fulfilled":{"id":[55]}},"top":{"middle":{"bottom":[101,102]}}}',
+        );
+
+         key= "top[middle][base]";
+        value = 999;
+        assertEquals(
+          JSON.stringify(createObjectForField(tempObj, key, value)),
+          '{"reminder":{"fulfilled":{"id":[55]}},"top":{"middle":{"bottom":[101,102],"base":999}}}',
+        );
+      }
+    })
+  }
 });


### PR DESCRIPTION
I was trying to work with a form with nested fields and found that in order to handle that we need to use the .stream() on the `ctx.request.body({ type: "form-data" }).value`. I was creating a method to handle the scenario and think it might be useful to have it as one of the helper methods in oak. Please let me know if there are any cases which I might be missing in order to get this be more generic. And what would be a good way to integrate this effectively with the .stream method in order to have this be similar to the .read method available on the body.value. 

PS. This is still a work in progress, and I would appreciate any suggestions regarding ways to improve or optimize the same.