### PR TITLE
fix Deno.ListenTlsOptions detection

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -111,8 +111,9 @@ export function isConn(value: unknown): value is Deno.Conn {
 export function isListenTlsOptions(
   value: unknown,
 ): value is Deno.ListenTlsOptions {
-  return typeof value === "object" && value !== null && "certFile" in value &&
-    "keyFile" in value && "port" in value;
+  return typeof value === "object" && value !== null &&
+    ("cert" in value || "certFile" in value) &&
+    ("key" in value || "keyFile" in value) && "port" in value;
 }
 
 export interface ReadableStreamFromReaderOptions {


### PR DESCRIPTION
The keyFile and certFile options are marked as "deprecated" in deno.d.ts.

```typescript
app.listen({ port: 443, secure: true, key: "...", cert: "..." })
```