### PR TITLE
fix: expose createHttpError

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -68,7 +68,7 @@ export type { CookiesGetOptions, CookiesSetDeleteOptions } from "./cookies.ts";
 export * as etag from "./etag.ts";
 export { HttpServer as HttpServerNative } from "./http_server_native.ts";
 export type { NativeRequest } from "./http_server_native_request.ts";
-export { HttpError, httpErrors, isHttpError } from "./httpError.ts";
+export { HttpError, httpErrors, isHttpError, createHttpError} from "./httpError.ts";
 export { proxy } from "./middleware/proxy.ts";
 export type { ProxyOptions } from "./middleware/proxy.ts";
 export { compose as composeMiddleware } from "./middleware.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -68,7 +68,12 @@ export type { CookiesGetOptions, CookiesSetDeleteOptions } from "./cookies.ts";
 export * as etag from "./etag.ts";
 export { HttpServer as HttpServerNative } from "./http_server_native.ts";
 export type { NativeRequest } from "./http_server_native_request.ts";
-export { HttpError, httpErrors, isHttpError, createHttpError} from "./httpError.ts";
+export {
+  createHttpError,
+  HttpError,
+  httpErrors,
+  isHttpError,
+} from "./httpError.ts";
 export { proxy } from "./middleware/proxy.ts";
 export type { ProxyOptions } from "./middleware/proxy.ts";
 export { compose as composeMiddleware } from "./middleware.ts";

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -40,6 +40,6 @@ test({
     assertEquals(typeof mod.send, "function");
     assertEquals(typeof mod.testing, "object");
     assertEquals(Object.keys(mod.testing).length, 4);
-    assertEquals(Object.keys(mod).length, 26);
+    assertEquals(Object.keys(mod).length, 27);
   },
 });


### PR DESCRIPTION
Expose `createHttpError` so it can be used for error handling on apps.