### PR TITLE
fix(router): add missing generic parameters for multiple middlewares

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -639,7 +639,7 @@ export class Router<
   >(
     nameOrPath: string,
     pathOrMiddleware: string | RouterMiddleware<string, P, S>,
-    ...middleware: RouterMiddleware<string, S>[]
+    ...middleware: RouterMiddleware<string, P, S>[]
   ): Router<S extends RS ? S : (S & RS)>;
   all<
     P extends RouteParams<string> = RouteParams<string>,
@@ -647,7 +647,7 @@ export class Router<
   >(
     nameOrPath: string,
     pathOrMiddleware: string | RouterMiddleware<string, P, S>,
-    ...middleware: RouterMiddleware<string, S>[]
+    ...middleware: RouterMiddleware<string, P, S>[]
   ): Router<S extends RS ? S : (S & RS)> {
     this.#useVerb(
       nameOrPath,
@@ -1001,7 +1001,7 @@ export class Router<
   >(
     nameOrPath: string,
     pathOrMiddleware: string | RouterMiddleware<string, P, S>,
-    ...middleware: RouterMiddleware<string, S>[]
+    ...middleware: RouterMiddleware<string, P, S>[]
   ): Router<S extends RS ? S : (S & RS)>;
   patch<
     P extends RouteParams<string> = RouteParams<string>,
@@ -1009,7 +1009,7 @@ export class Router<
   >(
     nameOrPath: string,
     pathOrMiddleware: string | RouterMiddleware<string, P, S>,
-    ...middleware: RouterMiddleware<string, S>[]
+    ...middleware: RouterMiddleware<string, P, S>[]
   ): Router<S extends RS ? S : (S & RS)> {
     this.#useVerb(
       nameOrPath,

--- a/router_test.ts
+++ b/router_test.ts
@@ -725,6 +725,24 @@ test({
 });
 
 test({
+  name: "router state types",
+  fn() {
+    const router = new Router<{ foo: string }>();
+    router.patch<{ id: string }>(
+      "/:id\\:archive",
+      (ctx) => {
+        ctx.params.id;
+        ctx.state.foo;
+      },
+      (ctx) => {
+        ctx.params.id;
+        ctx.state.foo;
+      },
+    );
+  },
+});
+
+test({
   name: "middleware returned from router.routes() passes next",
   async fn() {
     const { context } = setup("/foo", "GET");


### PR DESCRIPTION
Thank you for merging my previous PR.
Unfortunately I now noticed, that there where some missing generic parameters, that I simply copied over last time (or rather did not copy, because they weren't there :-D)
They cause the `router.all` and `router.patch` methods to not be usable with explicit route parameters and application state.
I have added a test for this specific case and inserted the missing generic parameters.
For the other methods they were already used like this, so I think this was the original intention.