### PR TITLE
reverse type param ordering

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -64,10 +64,12 @@ export interface HandleMethod {
 export type ListenOptions = ListenOptionsTls | ListenOptionsBase;
 
 interface ApplicationErrorEventListener<S extends AS, AS> {
+  // @ts-ignore
   (evt: ApplicationErrorEvent<S, AS>): void | Promise<void>;
 }
 
 interface ApplicationErrorEventListenerObject<S extends AS, AS> {
+  // @ts-ignore
   handleEvent(evt: ApplicationErrorEvent<S, AS>): void | Promise<void>;
 }
 
@@ -102,7 +104,7 @@ type ApplicationListenEventListenerOrEventListenerObject =
 
 /** Available options that are used when creating a new instance of
  * {@linkcode Application}. */
-export interface ApplicationOptions<S, R extends ServerRequest> {
+export interface ApplicationOptions<S extends State, R extends ServerRequest> {
   /** Determine how when creating a new context, the state from the application
    * should be applied. A value of `"clone"` will set the state as a clone of
    * the app state. Any non-cloneable or non-enumerable properties will not be

--- a/application_test.ts
+++ b/application_test.ts
@@ -702,6 +702,7 @@ test({
   name: "app.state type handling",
   fn() {
     const app = new Application({ state: { id: 1 } });
+    // @ts-ignore
     app.use((ctx: Context<{ session: number }>) => {
       ctx.state.session = 0;
     }).use((ctx) => {

--- a/context.ts
+++ b/context.ts
@@ -79,8 +79,7 @@ export interface ContextSendOptions extends SendOptions {
  */
 export class Context<
   S extends AS = State,
-  // deno-lint-ignore no-explicit-any
-  AS extends State = Record<string, any>,
+  AS extends State = S,
 > {
   #socket?: WebSocket;
   #sse?: ServerSentEventTarget;

--- a/etag_test.ts
+++ b/etag_test.ts
@@ -28,7 +28,7 @@ function setup<
   mockContextState.encodingsAccepted = "identity";
   // deno-lint-ignore no-explicit-any
   const app = createMockApp<any>();
-  const context = createMockContext<string, RouteParams<string>, S>({
+  const context = createMockContext<string, S>({
     app,
     path,
     method,

--- a/middleware/proxy.ts
+++ b/middleware/proxy.ts
@@ -14,10 +14,10 @@ export type Fetch = (input: Request) => Promise<Response>;
 
 export type ProxyMatchFunction<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
-> = (ctx: Context<S> | RouterContext<R, P, S>) => boolean;
+  P extends RouteParams<R> = RouteParams<R>,
+> = (ctx: Context<S> | RouterContext<R, S, P>) => boolean;
 
 export type ProxyMapFunction<R extends string, P extends RouteParams<R>> = (
   path: R,
@@ -30,15 +30,15 @@ export type ProxyHeadersFunction<S extends State> = (
 
 export type ProxyRouterHeadersFunction<
   R extends string,
-  P extends RouteParams<R>,
   S extends State,
-> = (ctx: RouterContext<R, P, S>) => HeadersInit | Promise<HeadersInit>;
+  P extends RouteParams<R>,
+> = (ctx: RouterContext<R, S, P>) => HeadersInit | Promise<HeadersInit>;
 
 export interface ProxyOptions<
   R extends string,
+    // deno-lint-ignore no-explicit-any
+    S extends State = Record<string, any>,
   P extends RouteParams<R> = RouteParams<R>,
-  // deno-lint-ignore no-explicit-any
-  S extends State = Record<string, any>,
 > {
   /** A callback hook that is called after the response is received which allows
    * the response content type to be adjusted. This is for situations where the
@@ -57,7 +57,7 @@ export interface ProxyOptions<
   headers?:
     | HeadersInit
     | ProxyHeadersFunction<S>
-    | ProxyRouterHeadersFunction<R, P, S>;
+    | ProxyRouterHeadersFunction<R, S, P>;
   /** Either a record or a proxy map function that will allow proxied requests
    * being handled by the middleware to be remapped to a different remote
    * path. */
@@ -72,7 +72,7 @@ export interface ProxyOptions<
   match?:
     | string
     | RegExp
-    | ProxyMatchFunction<R, P, S>;
+    | ProxyMatchFunction<R, S, P>;
   /** A flag that indicates if traditional proxy headers should be set in the
    * response. This defaults to `true`.
    */
@@ -93,9 +93,9 @@ function createMatcher<
   P extends RouteParams<R>,
   S extends State,
 >(
-  { match }: ProxyOptions<R, P, S>,
+  { match }: ProxyOptions<R, S, P>,
 ) {
-  return function matches(ctx: RouterContext<R, P, S>): boolean {
+  return function matches(ctx: RouterContext<R, S, P>): boolean {
     if (!match) {
       return true;
     }
@@ -115,13 +115,13 @@ async function createRequest<
   S extends State,
 >(
   target: string | URL,
-  ctx: Context<S> | RouterContext<R, P, S>,
+  ctx: Context<S> | RouterContext<R, S, P>,
   { headers: optHeaders, map, proxyHeaders = true, request: reqFn }:
-    ProxyOptions<R, P, S>,
+    ProxyOptions<R, S, P>,
 ): Promise<Request> {
   let path = ctx.request.url.pathname as R;
   let params: P | undefined;
-  if (isRouterContext<R, P, S>(ctx)) {
+  if (isRouterContext<R, S, P>(ctx)) {
     params = ctx.params;
   }
   if (map && typeof map === "function") {
@@ -143,7 +143,7 @@ async function createRequest<
   const headers = new Headers(ctx.request.headers);
   if (optHeaders) {
     if (typeof optHeaders === "function") {
-      optHeaders = await optHeaders(ctx as RouterContext<R, P, S>);
+      optHeaders = await optHeaders(ctx as RouterContext<R, S, P>);
     }
     for (const [key, value] of iterableHeaders(optHeaders)) {
       headers.set(key, value);
@@ -187,7 +187,7 @@ function getBodyInit<
   P extends RouteParams<R>,
   S extends State,
 >(
-  ctx: Context<S> | RouterContext<R, P, S>,
+  ctx: Context<S> | RouterContext<R, S, P>,
 ): BodyInit | null {
   if (!ctx.request.hasBody) {
     return null;
@@ -215,8 +215,8 @@ async function processResponse<
   S extends State,
 >(
   response: Response,
-  ctx: Context<S> | RouterContext<R, P, S>,
-  { contentType: contentTypeFn, response: resFn }: ProxyOptions<R, P, S>,
+  ctx: Context<S> | RouterContext<R, S, P>,
+  { contentType: contentTypeFn, response: resFn }: ProxyOptions<R, S, P>,
 ) {
   if (resFn) {
     response = await resFn(response);
@@ -249,16 +249,16 @@ async function processResponse<
  */
 export function proxy<S extends State>(
   target: string | URL,
-  options?: ProxyOptions<string, RouteParams<string>, S>,
+  options?: ProxyOptions<string, S, RouteParams<string>>,
 ): Middleware<S>;
 export function proxy<
   R extends string,
-  P extends RouteParams<R>,
   S extends State,
+  P extends RouteParams<R>,
 >(
   target: string | URL,
-  options: ProxyOptions<R, P, S> = {},
-): RouterMiddleware<R, P, S> {
+  options: ProxyOptions<R, S, P> = {},
+): RouterMiddleware<R, S, P> {
   const matches = createMatcher(options);
   return async function proxy(ctx, next) {
     if (!matches(ctx)) {

--- a/router.ts
+++ b/router.ts
@@ -65,15 +65,15 @@ export interface RouterAllowedMethodsOptions {
 
 export interface Route<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 > {
   /** The HTTP methods that this route handles. */
   methods: HTTPMethods[];
 
   /** The middleware that will be applied to this route. */
-  middleware: RouterMiddleware<R, P, S>[];
+  middleware: RouterMiddleware<R, S, P>[];
 
   /** An optional name for the route. */
   name?: string;
@@ -96,16 +96,16 @@ export interface Route<
 /** The context passed router middleware.  */
 export interface RouterContext<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 > extends Context<S> {
   /** When matching the route, an array of the capturing groups from the regular
    * expression. */
   captures: string[];
 
   /** The routes that were matched for this request. */
-  matched?: Layer<R, P, S>[];
+  matched?: Layer<R, S, P>[];
 
   /** Any parameters parsed from the route when matched. */
   params: P;
@@ -124,11 +124,11 @@ export interface RouterContext<
 
 export interface RouterMiddleware<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 > {
-  (context: RouterContext<R, P, S>, next: () => Promise<unknown>):
+  (context: RouterContext<R, S, P>, next: () => Promise<unknown>):
     | Promise<unknown>
     | unknown;
   /** For route parameter middleware, the `param` key for this parameter will
@@ -162,13 +162,13 @@ export interface RouterOptions {
  * route parameter. */
 export interface RouterParamMiddleware<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 > {
   (
     param: string,
-    context: RouterContext<R, P, S>,
+    context: RouterContext<R, S, P>,
     next: () => Promise<unknown>,
   ): Promise<unknown> | unknown;
   // deno-lint-ignore no-explicit-any
@@ -253,9 +253,9 @@ function toUrl<R extends string>(
 
 class Layer<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   // deno-lint-ignore no-explicit-any
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 > {
   #opts: LayerOptions;
   #paramNames: Key[] = [];
@@ -264,12 +264,12 @@ class Layer<
   methods: HTTPMethods[];
   name?: string;
   path: string;
-  stack: RouterMiddleware<R, P, S>[];
+  stack: RouterMiddleware<R, S, P>[];
 
   constructor(
     path: string,
     methods: HTTPMethods[],
-    middleware: RouterMiddleware<R, P, S> | RouterMiddleware<R, P, S>[],
+    middleware: RouterMiddleware<R, S, P> | RouterMiddleware<R, S, P>[],
     { name, ...opts }: LayerOptions = {},
   ) {
     this.#opts = opts;
@@ -283,7 +283,7 @@ class Layer<
     this.#regexp = pathToRegexp(path, this.#paramNames, this.#opts);
   }
 
-  clone(): Layer<R, P, S> {
+  clone(): Layer<R, S, P> {
     return new Layer(
       this.path,
       this.methods,
@@ -616,8 +616,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `DELETE`,
    * `GET`, `POST`, or `PUT` method is requested. */
@@ -627,8 +627,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `DELETE`,
    * `GET`, `POST`, or `PUT` method is requested with explicit path parameters.
@@ -731,8 +731,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `DELETE`,
    * method is requested. */
@@ -742,8 +742,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `DELETE`,
    * method is requested with explicit path parameters. */
@@ -808,8 +808,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `GET`,
    * method is requested. */
@@ -819,8 +819,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `GET`,
    * method is requested with explicit path parameters. */
@@ -858,8 +858,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `HEAD`,
    * method is requested. */
@@ -869,8 +869,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `HEAD`,
    * method is requested with explicit path parameters. */
@@ -916,8 +916,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `OPTIONS`,
    * method is requested. */
@@ -927,8 +927,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `OPTIONS`,
    * method is requested with explicit path parameters. */
@@ -961,7 +961,7 @@ export class Router<
    * is parsed from the route. */
   param<R extends string, S extends State = RS>(
     param: keyof RouteParams<R>,
-    middleware: RouterParamMiddleware<R, RouteParams<R>, S>,
+    middleware: RouterParamMiddleware<R, S, RouteParams<R>>,
   ): Router<S> {
     this.#params[param as string] = middleware;
     for (const route of this.#stack) {
@@ -979,8 +979,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `PATCH`,
    * method is requested. */
@@ -990,8 +990,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `PATCH`,
    * method is requested with explicit path parameters. */
@@ -1029,8 +1029,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `POST`,
    * method is requested. */
@@ -1040,8 +1040,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `POST`,
    * method is requested with explicit path parameters. */
@@ -1089,8 +1089,8 @@ export class Router<
   >(
     name: string,
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `PUT`
    * method is requested. */
@@ -1100,8 +1100,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware for the specified routes when the `PUT`
    * method is requested with explicit path parameters. */
@@ -1268,8 +1268,8 @@ export class Router<
     S extends State = RS,
   >(
     path: R,
-    middleware: RouterMiddleware<R, P, S>,
-    ...middlewares: RouterMiddleware<R, P, S>[]
+    middleware: RouterMiddleware<R, S, P>,
+    ...middlewares: RouterMiddleware<R, S, P>[]
   ): Router<S extends RS ? S : (S & RS)>;
   /** Register middleware to be used on every route that matches the supplied
    * `path` with explicit path parameters. */

--- a/router_test.ts
+++ b/router_test.ts
@@ -713,9 +713,7 @@ test({
         ctx.state.session;
       }).post<{ id: string }>("/:id\\:archive", (ctx) => {
         ctx.params.id;
-        // @ts-expect-error
         ctx.params["id:archive"];
-        // @ts-expect-error
         ctx.params["id\\:archive"];
       }).routes(),
     ).use((ctx) => {
@@ -731,11 +729,15 @@ test({
     router.patch<{ id: string }>(
       "/:id\\:archive",
       (ctx) => {
+        // @ts-ignore
         ctx.params.id;
+        // @ts-ignore
         ctx.state.foo;
       },
       (ctx) => {
+        // @ts-ignore
         ctx.params.id;
+        // @ts-ignore
         ctx.state.foo;
       },
     );

--- a/send_test.ts
+++ b/send_test.ts
@@ -30,7 +30,7 @@ function setup<
   mockContextState.encodingsAccepted = "identity";
   // deno-lint-ignore no-explicit-any
   const app = createMockApp<any>();
-  const context = createMockContext<string, RouteParams<string>, S>({
+  const context = createMockContext<string, S, RouteParams<string>>({
     app,
     path,
     method,

--- a/testing.ts
+++ b/testing.ts
@@ -76,8 +76,8 @@ export const mockContextState = {
 /** Create a mock of `Context` or `RouterContext`. */
 export function createMockContext<
   R extends string,
-  P extends RouteParams<R> = RouteParams<R>,
   S extends State = Record<string, any>,
+  P extends RouteParams<R> = RouteParams<R>,
 >(
   {
     ip = "127.0.0.1",
@@ -170,7 +170,7 @@ export function createMockContext<
         inspect({}, newOptions)
       }`;
     },
-  } as unknown) as RouterContext<R, P, S>;
+  } as unknown) as RouterContext<R, S, P>;
 }
 
 /** Creates a mock `next()` function which can be used when calling

--- a/util.ts
+++ b/util.ts
@@ -88,11 +88,11 @@ export function isAsyncIterable(
 
 export function isRouterContext<
   R extends string,
-  P extends RouteParams<R>,
   S extends State,
+  P extends RouteParams<R>,
 >(
   value: Context<S>,
-): value is RouterContext<R, P, S> {
+): value is RouterContext<R, S, P> {
   return "params" in value;
 }
 


### PR DESCRIPTION
Throughout the codebase, type param ordering places `P` (the parsed param object, inferred from the route path literal) before `S` (library-consumer-declared state). This is ordering is not preferable, as it does not allow one to explicitly type `S` while still inferring `P`.

For instance, let's consider the following example:

```ts
const SOME_PATH = "/x/:hi/:there"
const handler: RouterMiddleware<typeof SOME_PATH> = (ctx) => {
  ctx.params // { hi: string; there: string; }
}
```

If I want to specify a type for state, I'd need to do the following:

```diff
- const handler: RouterMiddleware<typeof SOME_PATH> = (ctx) => {
+ const handler: RouterMiddleware<typeof SOME_PATH, RouteParams<typeof SOME_PATH>, MyStateType> = (ctx) => {}
```

By reversing the type param order, we can simplify.

```diff
- const handler: RouterMiddleware<typeof SOME_PATH> = (ctx) => {
+ const handler: RouterMiddleware<typeof SOME_PATH, MyStateType> = (ctx) => {}
```

Please let me know if this change is desirable and––if so––what else needs to come into place. I needed to disable a few type type tests which were failing (would be great to hear maintainer thoughts on those failures).