### PR TITLE
feat: add MiddlewareObject

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -6,7 +6,6 @@ import { HttpServer } from "./http_server_native.ts";
 import { NativeRequest } from "./http_server_native_request.ts";
 import {
   compose,
-  Middleware,
   MiddlewareObject,
   MiddlewareOrMiddlewareObject,
 } from "./middleware.ts";

--- a/application.ts
+++ b/application.ts
@@ -6,8 +6,8 @@ import { HttpServer } from "./http_server_native.ts";
 import { NativeRequest } from "./http_server_native_request.ts";
 import {
   compose,
-  MiddlewareObject,
-  MiddlewareOrMiddlewareObject,
+  isMiddlewareObject,
+  type MiddlewareOrMiddlewareObject,
 } from "./middleware.ts";
 import { cloneState } from "./structured_clone.ts";
 import {
@@ -576,7 +576,7 @@ export class Application<AS extends State = Record<string, any>>
       throw new TypeError("There is no middleware to process requests.");
     }
     for (const middleware of this.#middleware) {
-      if (typeof middleware.init === "function") {
+      if (isMiddlewareObject(middleware) && middleware.init) {
         await middleware.init();
       }
     }

--- a/application.ts
+++ b/application.ts
@@ -4,7 +4,12 @@ import { Context } from "./context.ts";
 import { KeyStack, Status, STATUS_TEXT } from "./deps.ts";
 import { HttpServer } from "./http_server_native.ts";
 import { NativeRequest } from "./http_server_native_request.ts";
-import { compose, Middleware } from "./middleware.ts";
+import {
+  compose,
+  Middleware,
+  MiddlewareObject,
+  MiddlewareOrMiddlewareObject,
+} from "./middleware.ts";
 import { cloneState } from "./structured_clone.ts";
 import {
   Key,
@@ -303,7 +308,7 @@ export class Application<AS extends State = Record<string, any>>
   >;
   #contextState: "clone" | "prototype" | "alias" | "empty";
   #keys?: KeyStack;
-  #middleware: Middleware<State, Context<State, AS>>[] = [];
+  #middleware: MiddlewareOrMiddlewareObject<State, Context<State, AS>>[] = [];
   #serverConstructor: ServerConstructor<ServerRequest>;
 
   /** A set of keys, or an instance of `KeyStack` which will be used to sign
@@ -571,6 +576,11 @@ export class Application<AS extends State = Record<string, any>>
     if (!this.#middleware.length) {
       throw new TypeError("There is no middleware to process requests.");
     }
+    for (const middleware of this.#middleware) {
+      if (typeof middleware.init === "function") {
+        await middleware.init();
+      }
+    }
     if (typeof options === "string") {
       const match = ADDR_REGEXP.exec(options);
       if (!match) {
@@ -651,11 +661,11 @@ export class Application<AS extends State = Record<string, any>>
    * ```
    */
   use<S extends State = AS>(
-    middleware: Middleware<S, Context<S, AS>>,
-    ...middlewares: Middleware<S, Context<S, AS>>[]
+    middleware: MiddlewareOrMiddlewareObject<S, Context<S, AS>>,
+    ...middlewares: MiddlewareOrMiddlewareObject<S, Context<S, AS>>[]
   ): Application<S extends AS ? S : (S & AS)>;
   use<S extends State = AS>(
-    ...middleware: Middleware<S, Context<S, AS>>[]
+    ...middleware: MiddlewareOrMiddlewareObject<S, Context<S, AS>>[]
   ): Application<S extends AS ? S : (S & AS)> {
     this.#middleware.push(...middleware);
     this.#composedMiddleware = undefined;

--- a/examples/countingServer.ts
+++ b/examples/countingServer.ts
@@ -12,8 +12,8 @@ import {
 } from "https://deno.land/std@0.178.0/fmt/colors.ts";
 
 import {
-  composeMiddleware,
   Application,
+  composeMiddleware,
   type Context,
   type MiddlewareObject,
   type Next,
@@ -42,7 +42,10 @@ class LoggerMiddleware implements MiddlewareObject {
   #composedMiddleware: (context: Context, next: Next) => Promise<unknown>;
 
   constructor() {
-    this.#composedMiddleware = composeMiddleware([this.#handleLogger, this.#handleResponseTime]);
+    this.#composedMiddleware = composeMiddleware([
+      this.#handleLogger,
+      this.#handleResponseTime,
+    ]);
   }
 
   async #handleLogger(ctx: Context, next: Next) {

--- a/examples/countingServer.ts
+++ b/examples/countingServer.ts
@@ -1,15 +1,13 @@
-/*
- * This is an example of how to use an object as a middleware. MiddlewareObject
- * can be ideal for when a middleware needs to encapsulate large amounts of
- * logic or its own state.
- */
+/* This is an example of how to use an object as a middleware.
+ * `MiddlewareObject` can be ideal for when a middleware needs to encapsulate
+ * large amounts of logic or its own state. */
 
 import {
   bold,
   cyan,
   green,
   yellow,
-} from "https://deno.land/std@0.178.0/fmt/colors.ts";
+} from "https://deno.land/std@0.183.0/fmt/colors.ts";
 
 import {
   Application,

--- a/examples/countingServer.ts
+++ b/examples/countingServer.ts
@@ -1,0 +1,87 @@
+/*
+ * This is an example of how to use an object as a middleware. MiddlewareObject
+ * can be ideal for when a middleware needs to encapsulate large amounts of
+ * logic or its own state.
+ */
+
+import {
+  bold,
+  cyan,
+  green,
+  yellow,
+} from "https://deno.land/std@0.178.0/fmt/colors.ts";
+
+import {
+  composeMiddleware,
+  Application,
+  type Context,
+  type MiddlewareObject,
+  type Next,
+} from "../mod.ts";
+
+const app = new Application();
+
+class CountingMiddleware implements MiddlewareObject {
+  #id = 0;
+  #counter = 0;
+
+  init() {
+    const array = new Uint32Array(1);
+    crypto.getRandomValues(array);
+    this.#id = array[0];
+  }
+
+  handleRequest(ctx: Context, next: Next) {
+    ctx.response.headers.set("X-Response-Count", String(this.#counter++));
+    ctx.response.headers.set("X-Response-Counter-ID", String(this.#id));
+    return next();
+  }
+}
+
+class LoggerMiddleware implements MiddlewareObject {
+  #composedMiddleware: (context: Context, next: Next) => Promise<unknown>;
+
+  constructor() {
+    this.#composedMiddleware = composeMiddleware([this.#handleLogger, this.#handleResponseTime]);
+  }
+
+  async #handleLogger(ctx: Context, next: Next) {
+    await next();
+    const rt = ctx.response.headers.get("X-Response-Time");
+    console.log(
+      `${green(ctx.request.method)} ${cyan(ctx.request.url.pathname)} - ${
+        bold(
+          String(rt),
+        )
+      }`,
+    );
+  }
+
+  async #handleResponseTime(ctx: Context, next: Next) {
+    const start = Date.now();
+    await next();
+    const ms = Date.now() - start;
+    ctx.response.headers.set("X-Response-Time", `${ms}ms`);
+  }
+
+  handleRequest(ctx: Context, next: Next) {
+    return this.#composedMiddleware(ctx, next);
+  }
+}
+
+app.use(new CountingMiddleware());
+app.use(new LoggerMiddleware());
+
+app.use((ctx) => {
+  ctx.response.body = "Hello World!";
+});
+
+app.addEventListener("listen", ({ hostname, port, serverType }) => {
+  console.log(
+    bold("Start listening on ") + yellow(`${hostname}:${port}`),
+  );
+  console.log(bold("  using HTTP server: " + yellow(serverType)));
+});
+
+await app.listen({ hostname: "127.0.0.1", port: 8000 });
+console.log(bold("Finished."));

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,8 +28,8 @@ export interface MiddlewareObject<
 
 /** Complete middleware type. */
 export type MiddlewareOrMiddlewareObject<
-S extends State = Record<string, any>,
-T extends Context = Context<S>,
+  S extends State = Record<string, any>,
+  T extends Context = Context<S>,
 > = Middleware<S, T> | MiddlewareObject<S, T>;
 
 /** Compose multiple middleware functions into a single middleware function. */

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,7 +8,8 @@ import type { Context } from "./context.ts";
 /** A function for chaining middleware. */
 export type Next = () => Promise<unknown>;
 
-/** Middleware are functions which are chained together to deal with requests. */
+/** Middleware are functions which are chained together to deal with
+ * requests. */
 export interface Middleware<
   S extends State = Record<string, any>,
   T extends Context = Context<S>,
@@ -16,21 +17,34 @@ export interface Middleware<
   (context: T, next: Next): Promise<unknown> | unknown;
 }
 
-/** Middleware can also be objects to encapsulate more logic and state. */
+/** Middleware objects allow encapsulation of middleware along with the ability
+ * to initialize the middleware upon listen. */
 export interface MiddlewareObject<
   S extends State = Record<string, any>,
   T extends Context<S> = Context<S>,
 > {
-  /** Optional function for delayed initialization. */
+  /** Optional function for delayed initialization which will be called when
+   * the application starts listening. */
   init?: () => Promise<unknown> | unknown;
+  /** The method to be called to handle the request. */
   handleRequest(context: T, next: Next): Promise<unknown> | unknown;
 }
 
-/** Complete middleware type. */
+/** Type that represents {@linkcode Middleware} or
+ * {@linkcode MiddlewareObject}. */
 export type MiddlewareOrMiddlewareObject<
   S extends State = Record<string, any>,
   T extends Context = Context<S>,
 > = Middleware<S, T> | MiddlewareObject<S, T>;
+
+/** A type guard that returns true if the value is
+ * {@linkcode MiddlewareObject}. */
+export function isMiddlewareObject<
+  S extends State = Record<string, any>,
+  T extends Context = Context<S>,
+>(value: MiddlewareOrMiddlewareObject<S, T>): value is MiddlewareObject<S, T> {
+  return value && typeof value === "object" && "handleRequest" in value;
+}
 
 /** Compose multiple middleware functions into a single middleware function. */
 export function compose<

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,12 +19,15 @@ export interface MiddlewareObject<
   T extends Context = Context<S>,
 > {
   /** Optional function for delayed initialization. */
-  init()?: Promise<unknown> | unknown;
+  init?: () => Promise<unknown> | unknown;
   handleRequest(context: T, next: () => Promise<unknown>): Promise<unknown> | unknown;
 }
 
 /** Complete middleware type. */
-export type MiddlewareOrMiddlewareObject = Middleware | MiddlewareObject;
+export type MiddlewareOrMiddlewareObject<
+S extends State = Record<string, any>,
+T extends Context = Context<S>,
+> = Middleware<S, T> | MiddlewareObject<S, T>;
 
 /** Compose multiple middleware functions into a single middleware function. */
 export function compose<

--- a/middleware_test.ts
+++ b/middleware_test.ts
@@ -5,11 +5,16 @@
 import { assert, assertEquals, assertStrictEquals } from "./test_deps.ts";
 import { errors } from "./deps.ts";
 import { createMockContext } from "./testing.ts";
-import { compose, Middleware, MiddlewareObject, Next } from "./middleware.ts";
+import {
+  compose,
+  isMiddlewareObject,
+  type Middleware,
+  type MiddlewareObject,
+  type Next,
+} from "./middleware.ts";
+import { Context } from "./context.ts";
 
-const { test } = Deno;
-
-test({
+Deno.test({
   name: "test compose()",
   async fn() {
     const callStack: number[] = [];
@@ -31,7 +36,25 @@ test({
   },
 });
 
-test({
+Deno.test({
+  name: "isMiddlewareObject()",
+  async fn() {
+    class MockMiddlewareObject implements MiddlewareObject {
+      handleRequest(
+        _context: Context<Record<string, any>, Record<string, any>>,
+        _next: Next,
+      ): unknown {
+        return;
+      }
+    }
+
+    assert(isMiddlewareObject(new MockMiddlewareObject()));
+    assert(isMiddlewareObject({ handleRequest() {} }));
+    assert(!isMiddlewareObject(function () {}));
+  },
+});
+
+Deno.test({
   name: "middleware objects are composed correctly",
   async fn() {
     const callStack: number[] = [];
@@ -56,7 +79,7 @@ test({
   },
 });
 
-test({
+Deno.test({
   name: "next() is catchable",
   async fn() {
     let caught: any;
@@ -76,7 +99,7 @@ test({
   },
 });
 
-test({
+Deno.test({
   name: "composed middleware accepts next middleware",
   async fn() {
     const callStack: number[] = [];

--- a/mod.ts
+++ b/mod.ts
@@ -68,7 +68,11 @@ export { type NativeRequest } from "./http_server_native_request.ts";
 export { proxy } from "./middleware/proxy.ts";
 export type { ProxyOptions } from "./middleware/proxy.ts";
 export { compose as composeMiddleware } from "./middleware.ts";
-export type { Middleware } from "./middleware.ts";
+export type {
+  Middleware,
+  MiddlewareObject,
+  MiddlewareOrMiddlewareObject,
+} from "./middleware.ts";
 export { FormDataReader } from "./multipart.ts";
 export type {
   FormDataBody,

--- a/mod.ts
+++ b/mod.ts
@@ -72,6 +72,7 @@ export type {
   Middleware,
   MiddlewareObject,
   MiddlewareOrMiddlewareObject,
+  Next,
 } from "./middleware.ts";
 export { FormDataReader } from "./multipart.ts";
 export type {


### PR DESCRIPTION
This extends Middleware to allow objects to be used, making it similar to event targets.
It allows an optional `init` method that will be invoked when `listen` is called.

Objects will be useful for encapsulating larger amounts of logic or state, or when delayed initialization is desired such as a database driver.