### PR TITLE
Remove extra words in FAQ.md

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -56,8 +56,8 @@ app.use((ctx) => {
 await app.listen({ port: 8000 });
 ```
 
-The symbol `REDIRECT_BACK` can be used to redirect the requestor back to the to
-the referrer (if the request's `Referer` header has been set), and the second
+The symbol `REDIRECT_BACK` can be used to redirect the requestor back to the
+referrer (if the request's `Referer` header has been set), and the second
 argument can be used to provide a "backup" if there is no referrer. For example:
 
 ```ts


### PR DESCRIPTION
Hey, I was looking at the spelling of 'referer' and 'referrer', directly following where I deleted those words...

Am I missing something, or is that actually correct the way it is? lol