### PR TITLE
fix: http_server_native when closing with signal abort event

### DIFF
--- a/http_server_native.test.ts
+++ b/http_server_native.test.ts
@@ -37,7 +37,7 @@ Deno.test({
   async fn() {
     const abortController = new AbortController();
     const app = new Application();
-    const listenOptions = { port: 4505, signal: abortController.signal};
+    const listenOptions = { port: 4505, signal: abortController.signal };
 
     const server = new Server(app, listenOptions);
     server.listen();

--- a/http_server_native.test.ts
+++ b/http_server_native.test.ts
@@ -35,8 +35,9 @@ Deno.test({
   name: "HttpServer closes gracefully after serving requests",
   ignore: isNode(),
   async fn() {
+    const abortController = new AbortController();
     const app = new Application();
-    const listenOptions = { port: 4505 };
+    const listenOptions = { port: 4505, signal: abortController.signal};
 
     const server = new Server(app, listenOptions);
     server.listen();
@@ -56,7 +57,7 @@ Deno.test({
       console.error(e);
       unreachable();
     } finally {
-      await server.close();
+      abortController.abort();
     }
   },
 });

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -92,7 +92,7 @@ export class Server<AS extends State = Record<string, any>>
         });
       },
     });
-    
+
     signal?.addEventListener("abort", () => this.close(), { once: true });
     return promise;
   }

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -71,7 +71,6 @@ export class Server<AS extends State = Record<string, any>>
       throw new Error("Server already listening.");
     }
     const { signal } = this.#options;
-    signal?.addEventListener("abort", () => this.close(), { once: true });
     const { onListen, ...options } = this.#options;
     const { promise, resolve } = createPromiseWithResolvers<Listener>();
     this.#stream = new ReadableStream<NativeRequest>({
@@ -93,7 +92,8 @@ export class Server<AS extends State = Record<string, any>>
         });
       },
     });
-
+    
+    signal?.addEventListener("abort", () => this.close(), { once: true });
     return promise;
   }
 


### PR DESCRIPTION
Hello,

I recently discovered an issue when using Superoak and Oak v13.
It seems that the refactory performed to replace `Deno.serveHttp` with `Deno.server` caused the close method within the oak native http throw `Bad Resource ID` when the controller dispatched an abort event.

```
error: BadResource: Bad resource ID
              controller.abort();
                         ^
    at AbortSignal.CallbackContext.signal.addEventListener.once (ext:deno_http/00_serve.js:355:9)
    at innerInvokeEventListeners (ext:deno_web/02_event.js:754:7)
    at invokeEventListeners (ext:deno_web/02_event.js:801:5)
    at dispatch (ext:deno_web/02_event.js:658:9)
    at AbortSignal.dispatchEvent (ext:deno_web/02_event.js:1043:12)
    at AbortSignal.[[[signalAbort]]] (ext:deno_web/03_abort_signal.js:146:11)
    at AbortController.abort (ext:deno_web/03_abort_signal.js:280:30)
    at Object.close (https://deno.land/x/superoak@4.8.1/src/superoak.ts:72:26)
    at Object.close (https://deno.land/x/superdeno@4.9.0/src/test.ts:265:19)
    at close (https://deno.land/x/superdeno@4.9.0/src/close.ts:21:20)
```

To replicate this issue I replaced the direct call in the test with an AbortController that can dispatch the event to signal instead of calling `Server.close()` directly.

The fix was to move the initialization of the signal event listener after we defined the ReadableStream instance.