### PR TITLE
chore: run CI on canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   oak:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["v1.x", canary]
     steps:
       - name: clone repository
         uses: actions/checkout@v4
@@ -12,7 +15,7 @@ jobs:
       - name: install deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.X
+          deno-version: ${{ matrix.version }}
 
       - name: check format
         run: deno fmt --check


### PR DESCRIPTION
This PR enables Deno canary in CI, which currently is the same as enabling Deno 2.0.0-rc.0. This has the obvious benefit of future-proofing this package for Deno 2, but also gives us (Deno) early insight into any issues that users may run into when migrating from Deno 1 to 2.