### PR TITLE
Allow proxy middleware to reuse body from memo

### DIFF
--- a/body.test.ts
+++ b/body.test.ts
@@ -467,3 +467,19 @@ Deno.test({
     assert(timingSafeEqual(actual, expected));
   },
 });
+
+Deno.test({
+  name: "body - empty",
+  async fn() {
+    const body = new Body(nativeToServer(
+      new Request(
+        "http://localhost/index.html",
+        {
+          method: "GET",
+        },
+      ),
+    ));
+    assert(!body.has);
+    assertEquals(await body.init(), null);
+  },
+});

--- a/body.ts
+++ b/body.ts
@@ -89,6 +89,14 @@ export class Body {
     return this.#request?.bodyUsed ?? !!this.#used;
   }
 
+  /** Return the body to be reused as BodyInit. */
+  async init(): Promise<BodyInit | null> {
+    if (!this.has) {
+      return null;
+    }
+    return await this.#memo ?? this.stream;
+  }
+
   /** Reads a body to the end and resolves with the value as an
    * {@linkcode ArrayBuffer} */
   async arrayBuffer(): Promise<ArrayBuffer> {

--- a/middleware/proxy.ts
+++ b/middleware/proxy.ts
@@ -152,7 +152,7 @@ async function createRequest<
   }
   url.search = ctx.request.url.search;
 
-  const body = getBodyInit(ctx);
+  const body = await ctx.request.body?.init() ?? null;
   const headers = new Headers(ctx.request.headers);
   if (optHeaders) {
     if (typeof optHeaders === "function") {
@@ -193,19 +193,6 @@ async function createRequest<
     request = await reqFn(request);
   }
   return request;
-}
-
-function getBodyInit<
-  R extends string,
-  P extends RouteParams<R>,
-  S extends State,
->(
-  ctx: Context<S> | RouterContext<R, P, S>,
-): BodyInit | null {
-  if (!ctx.request.hasBody) {
-    return null;
-  }
-  return ctx.request.body.stream;
 }
 
 function iterableHeaders(

--- a/testing.ts
+++ b/testing.ts
@@ -16,6 +16,7 @@ import {
   type ErrorStatus,
   SecureCookieMap,
 } from "./deps.ts";
+import { Body } from "./body.ts";
 import type { RouteParams, RouterContext } from "./router.ts";
 import type { Request } from "./request.ts";
 import { Response } from "./response.ts";
@@ -67,6 +68,7 @@ export interface MockContextOptions<
   path?: string;
   state?: S;
   headers?: [string, string][];
+  body?: ReadableStream;
 }
 
 /** Allows external parties to modify the context state. */
@@ -90,6 +92,7 @@ export function createMockContext<
     state,
     app = createMockApp(state),
     headers: requestHeaders,
+    body = undefined,
   }: MockContextOptions<R> = {},
 ): RouterContext<R, P, S> {
   function createMockRequest(): Request {
@@ -120,6 +123,8 @@ export function createMockContext<
       search: undefined,
       searchParams: new URLSearchParams(),
       url: new URL(path, "http://localhost/"),
+      hasBody: !!body,
+      body: body ? new Body({ headers, getBody: () => body }) : undefined,
     } as any;
   }
 


### PR DESCRIPTION
When the body is consumed, it is still available in the `#memo` private property. All the possible types there are a match for `BodyInit`. So there is nothing preventing us from using it directly in the `proxy` middleware.

Resolves #642 