### PR TITLE
fix: close file on readAll exception

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -22,7 +22,6 @@ export {
 } from "jsr:@std/http@^1.0/negotiation";
 export { UserAgent } from "jsr:@std/http@^1.0/user-agent";
 export { LimitedReader } from "jsr:@std/io@0.224/limited-reader";
-export { readAll } from "jsr:@std/io@0.224/read-all";
 export { contentType } from "jsr:@std/media-types@^1.0/content-type";
 export { typeByExtension } from "jsr:@std/media-types@^1.0/type-by-extension";
 export {

--- a/send.ts
+++ b/send.ts
@@ -24,7 +24,6 @@ import {
   ifNoneMatch,
   parse,
   range,
-  readAll,
   responseRange,
   Status,
 } from "./deps.ts";
@@ -142,12 +141,11 @@ async function getEntity(
   let body: Uint8Array | Deno.FsFile;
   let entity: Uint8Array | FileInfo;
   const fileInfo = { mtime: new Date(mtime), size: stats.size };
-  const file = await Deno.open(path, { read: true });
   if (stats.size < maxbuffer) {
-    const buffer = await readAll(file);
-    file.close();
+    const buffer = await Deno.readFile(path);
     body = entity = buffer;
   } else {
+    const file = await Deno.open(path, { read: true });
     response.addResource(file);
     body = file;
     entity = fileInfo;


### PR DESCRIPTION
The file would remain open on a `readAll` exception.