### PR TITLE
Update vulnerable path-to-regexp version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -83,4 +83,4 @@ export {
   type ParseOptions,
   pathToRegexp,
   type TokensToRegexpOptions,
-} from "npm:path-to-regexp@6.2.1";
+} from "npm:path-to-regexp@^6.3.0";


### PR DESCRIPTION
There is a vulnerability that is fixed by this update:

> path-to-regexp  4.0.0 - 6.2.2
> Severity: high
> path-to-regexp outputs backtracking regular expressions - https://github.com/advisories/GHSA-9wv6-86v2-598j