### PR TITLE
fix: make Application listen promise resolve after aborted

### DIFF
--- a/application.test.ts
+++ b/application.test.ts
@@ -1116,7 +1116,7 @@ Deno.test({
     const { signal } = controller;
     const p = app.listen({ signal });
     controller.abort();
-    assertRejects(
+    await assertRejects(
       async () => await p,
       "aborted prematurely before 'listen' event",
     );

--- a/application.test.ts
+++ b/application.test.ts
@@ -1134,7 +1134,7 @@ Deno.test({
     });
     const { signal } = controller;
     const p = app.listen({ signal });
-    app.addEventListener("listen", async () => controller.abort());
+    app.addEventListener("listen", () => controller.abort());
     const GRACEFUL_TIME = 1000;
     let timer: number | undefined;
     const raceResult = await Promise.race([

--- a/application.test.ts
+++ b/application.test.ts
@@ -1154,6 +1154,7 @@ Deno.test({
       raceResult === "resolved cleanly",
       `'listen promise' should resolve before ${GRACEFUL_TIME} ms`,
     );
+    teardown();
   },
 });
 

--- a/application.test.ts
+++ b/application.test.ts
@@ -1138,10 +1138,11 @@ Deno.test({
     const GRACEFUL_TIME = 1000;
     let timer: number | undefined;
     const raceResult = await Promise.race([
-      new Promise(async (resolve) => {
-        await p;
-        clearTimeout(timer);
-        resolve("resolved cleanly");
+      new Promise((resolve) => {
+        p.then(() => {
+          clearTimeout(timer);
+          resolve("resolved cleanly");
+        });
       }),
       new Promise((resolve) =>
         timer = setTimeout(

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -79,6 +79,10 @@ export class Server<AS extends State = Record<string, any>>
     const { signal } = this.#options;
     const { onListen, ...options } = this.#options;
     const { promise, resolve } = createPromiseWithResolvers<Listener>();
+    if (signal?.aborted) {
+      // if user somehow aborted before `listen` is invoked, we throw
+      return Promise.reject(new Error("aborted prematurely before 'listen' event"));
+    }
     this.#stream = new ReadableStream<NativeRequest>({
       start: (controller) => {
         this.#httpServer = serve?.({

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -96,6 +96,9 @@ export class Server<AS extends State = Record<string, any>>
           signal,
           ...options,
         });
+        // closinng stream, so that the Application listen promise can resolve itself
+        // https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close
+        signal?.addEventListener("abort", () => controller.close(), { once: true });
       },
     });
 

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -81,7 +81,9 @@ export class Server<AS extends State = Record<string, any>>
     const { promise, resolve } = createPromiseWithResolvers<Listener>();
     if (signal?.aborted) {
       // if user somehow aborted before `listen` is invoked, we throw
-      return Promise.reject(new Error("aborted prematurely before 'listen' event"));
+      return Promise.reject(
+        new Error("aborted prematurely before 'listen' event"),
+      );
     }
     this.#stream = new ReadableStream<NativeRequest>({
       start: (controller) => {
@@ -102,7 +104,9 @@ export class Server<AS extends State = Record<string, any>>
         });
         // closinng stream, so that the Application listen promise can resolve itself
         // https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close
-        signal?.addEventListener("abort", () => controller.close(), { once: true });
+        signal?.addEventListener("abort", () => controller.close(), {
+          once: true,
+        });
       },
     });
 

--- a/http_server_native.ts
+++ b/http_server_native.ts
@@ -102,7 +102,7 @@ export class Server<AS extends State = Record<string, any>>
           signal,
           ...options,
         });
-        // closinng stream, so that the Application listen promise can resolve itself
+        // closing stream, so that the Application listen promise can resolve itself
         // https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close
         signal?.addEventListener("abort", () => controller.close(), {
           once: true,


### PR DESCRIPTION
Hi Oak community / cc @kitsonk,

---

Edited on 12th Dec 24: should close #686 and close #687 

---

I'm using Oak heavily at work (kudos to all for the cool library of course 😀).

I notice (at current version `v17.1.3`) the server listen promise doesn't resolve itself even after already `abort`ed.

#### Naive reproduction attempt:
```ts
const abortCtrl = new AbortController();
const { signal } = abortCtrl;
const app = new Application();
const p = app.listen({ signal });
setTimeout(() => abortCtrl.abort(), 2000); // simulate turning off the application after 2 seconds
await p;
console.log("application aborted, safe to shut down the parent process"); // <== unreachable line
```

If we do it like the above, then we never see the last line logged out in the console. This suggests the `await p` expression never resolves (forever staying at `pending` state).

I was a bit curious how it behaves differently from [the doc](https://github.com/oakserver/oak?tab=readme-ov-file#closing-the-server), so I dug a bit & it resulted in this PR.

I mark the PR as ready for visibility - always happy to consider alternatives or feedback :)

---
#### Side note:
During the process, I also noticed a related unit test was disabled. I think it was disabled due to another (slightly related) reason: the server needs a bit of time to initialize itself, so if we call `abort()` right after `listen()` (as done in the originally disabled test), then the signal is already `abort`ed by the time the server initializes, and so we "miss" the chance to properly abort it.

To this end, I also re-enabled that test, plus I added another test so we cover both scenarios. The PR content explains better than my words here tho 😀

---

Thank you everyone for your insights / reviews / discussions / objections etc. 🙌 !