### PR TITLE
fix: log warning when cloning state skips a value

### DIFF
--- a/utils/clone_state.ts
+++ b/utils/clone_state.ts
@@ -9,6 +9,9 @@ export function cloneState<S extends Record<string, any>>(state: S): S {
       const clonedValue = structuredClone(value);
       clone[key as keyof S] = clonedValue;
     } catch {
+      console.warn(
+        `Cannot clone value for: ${key}. Modify contextState to change this behavior.`,
+      );
       // we just no-op values that cannot be cloned
     }
   }


### PR DESCRIPTION
Hi, I encountered this while writing a small server with oak and my state was silently skipped. I thought a console.warn might be helpful here.

Thanks!