### PR TITLE
fix: don't return true for isNode() under Deno

### DIFF
--- a/utils/type_guards.ts
+++ b/utils/type_guards.ts
@@ -41,7 +41,8 @@ export function isNetAddr(value: unknown): value is NetAddr {
 
 export function isNode(): boolean {
   return "process" in globalThis && "global" in globalThis &&
-    !("Bun" in globalThis) && !("WebSocketPair" in globalThis);
+    !("Bun" in globalThis) && !("WebSocketPair" in globalThis) &&
+    !("Deno" in globalThis);
 }
 
 export function isFsFile(value: unknown): value is Deno.FsFile {


### PR DESCRIPTION
as of Deno 2.4, the 'process' and 'global' variables are set in the global environment, so it's better to explciitly exclude it now