### PR TITLE
docs: update links of path-to-regexp to 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,11 @@ await app.listen({ port: 8000 });
 ```
 
 A route passed is converted to a regular expression using
-[path-to-regexp](https://github.com/pillarjs/path-to-regexp), which means
-parameters expressed in the pattern will be converted. `path-to-regexp` has
-advanced usage which can create complex patterns which can be used for matching.
-Check out the
-[documentation for that library](https://github.com/pillarjs/path-to-regexp#parameters)
+[path-to-regexp](https://github.com/pillarjs/path-to-regexp/tree/6.x), which
+means parameters expressed in the pattern will be converted. `path-to-regexp`
+has advanced usage which can create complex patterns which can be used for
+matching. Check out the
+[documentation for that library](https://github.com/pillarjs/path-to-regexp/tree/6.x#parameters)
 if you have advanced use cases.
 
 In most cases, the type of `context.params` is automatically inferred from the


### PR DESCRIPTION
As mentioned in #684, path-to-regexp 8.x introduces significant changes on how users define routes. However, the links to path-to-regexp in README.md refer to 8.x, where the documented parameters hardly work at all, which confused me a lot when I first tried oak. This PRs updates the links to path-to-regexp 6.x so that new users can find the correct documentation.